### PR TITLE
Remove volatile corpus and binary size claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ different. ([docs/spec.md](docs/spec.md) §6.5; differential corpus
 Multi-backend languages usually ship a list of known divergences. There is no such
 list here, because a divergence is a red build:
 
-- `scripts/spike-native/run.sh` — 59 corpus programs compiled and run on both sides,
-  comparing **stdout, stderr and exit code**, plus an AddressSanitizer leg.
+- `scripts/spike-native/run.sh` — the differential corpus is compiled and run on both
+  sides, comparing **stdout, stderr and exit code**, plus an AddressSanitizer leg.
 - `scripts/intrinsic-parity.py` — walks the primitive table; any primitive implemented
   on only one backend is red.
 - `scripts/native-cli-diff.sh` — pins the native binary's `fmt`/`doc`/`add`/`lsp`
@@ -275,7 +275,7 @@ which one you are on:
 | Targets | wherever GraalVM runs | linux-x86_64 only |
 
 One file settles it. `examples/interop/interop.dawn` uses `use java`:
-`dawn build --native` writes a 15 MB executable that runs, while `dawnc check` on
+`dawn build --native` writes an executable that runs, while `dawnc check` on
 the same file answers `Java interop needs a JVM host with a class path to
 resolve java.lang.String against; this build has none`.
 
@@ -288,14 +288,14 @@ second backend".
 **This is also the scope of the parity claim above.** "Two backends, one answer"
 is a claim about the programs both backends can compile, and every program
 containing `use java` is outside it, because on those there is no second answer
-to compare against. The 59 programs under `scripts/spike-native/` are inside that
+to compare against. Every entry under `scripts/spike-native/` is inside that
 intersection by construction.
 
 ### The road without a JVM
 
 **As of v0.50.0**, every release also carries **`dawnc-linux-x86_64`**: a single-file
-static executable produced by the C backend (about 3.6 MB), with `std` and the C
-runtime embedded. It needs neither this repository nor a JVM.
+static executable produced by the C backend, with `std` and the C runtime embedded.
+It needs neither this repository nor a JVM.
 
 Its subcommands are `check|emitc|build|run|test|fmt|doc|add|lsp`; `build`/`run` invoke
 the machine's `cc` (overridable with `$CC`) and the rest do not touch a C toolchain at

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- doc-check: translation-of README.md @ af06bd9b28516620 -->
+<!-- doc-check: translation-of README.md @ 9385c8c73a9ee578 -->
 
 # Dawn
 
@@ -117,7 +117,7 @@ pub fn main() -> Unit !io = {
 
 多后端语言普遍带着一份「已知分歧」清单。这里没有，因为分歧会红灯：
 
-- `scripts/spike-native/run.sh`——59 个语料程序两边编、两边跑，比 **stdout、stderr、
+- `scripts/spike-native/run.sh`——整套差分语料两边编、两边跑，比 **stdout、stderr、
   退出码**，外加一档 AddressSanitizer。
 - `scripts/intrinsic-parity.py`——走原语表，任何 primitive 只在一个后端有实现就红。
 - `scripts/native-cli-diff.sh`——把 native 二进制的 `fmt`/`doc`/`add`/`lsp` 输出按**字节**
@@ -225,7 +225,7 @@ impl 一致性是全程序唯一映射）与 `[java-deps]`（coursier 解析 Mav
 | 目标平台 | GraalVM 能跑的地方 | 只有 linux-x86_64 |
 
 一个文件就能说清。`examples/interop/interop.dawn` 用了 `use java`：`dawn build --native`
-写出一个 15 MB、跑得起来的可执行文件；`dawnc check` 对同一个文件答的是
+写出一个跑得起来的可执行文件；`dawnc check` 对同一个文件答的是
 `Java interop needs a JVM host with a class path to resolve java.lang.String against;
 this build has none`。
 
@@ -235,12 +235,12 @@ C 后端，不是那个 flag。把 flag 读成「把 JVM 那份产物提前打�
 
 **上面那条对等承诺的范围也在这里。**「两个后端一个答案」说的是两个后端都能编的那些程序，
 凡是带 `use java` 的都在范围之外——那些程序根本没有第二个答案可比。`scripts/spike-native/`
-下的 59 个程序按构造就在这个交集里。
+下的每个语料入口按构造就在这个交集里。
 
 ### 不装 JVM 的那条路
 
 **从 v0.50.0 起**，每个 release 还挂着 **`dawnc-linux-x86_64`**：C 后端编出来的单文件静态
-可执行程序（约 3.6 MB），std 与 C 运行时都嵌在里面，不需要这个仓库、也不需要 JVM。
+可执行程序，std 与 C 运行时都嵌在里面，不需要这个仓库、也不需要 JVM。
 
 子命令是 `check|emitc|build|run|test|fmt|doc|add|lsp`；`build`/`run` 会调用机器上的 `cc`
 （`$CC` 可覆盖），其余的不碰 C 工具链。打包成 jar、`lock`、`cache` 需要 JVM，故不在它的

--- a/scripts/doc-check.py
+++ b/scripts/doc-check.py
@@ -1765,6 +1765,37 @@ REPOSITORY_POLICY_FILES = (
     "docs/package-design.md",
     "docs/spec.md",
     "docs/spec.en.md",
+    "site/pages/home.md",
+    "site/pages/home.zh.md",
+)
+
+# Exact corpus and artifact sizes in outward copy decay without changing any
+# decision a reader makes. The README's native differential grew from 59 to
+# more than a hundred entries while still advertising 59 in four places, and
+# the released native binary outgrew both size figures in the toolchain
+# walkthrough. GOV-11 already removed this class of volatile scale metric from
+# the introduction; keep it out of the other outward surfaces too rather than
+# making every corpus addition or toolchain build a translation edit.
+OUTWARD_CORPUS_COUNTS = (
+    ("README.md", re.compile(
+        r"(?:\b\d+\s+(?:differential\s+)?corpus (?:programs|entries)\b|"
+        r"\bThe \d+ programs under `scripts/spike-native/`)", re.I)),
+    ("site/pages/home.md", re.compile(
+        r"\b\d+\s+(?:differential\s+)?corpus (?:programs|entries)\b", re.I)),
+    ("README.zh-CN.md", re.compile(
+        r"(?:\d+\s*个(?:差分|对拍)?语料(?:程序|入口)|"
+        r"下的\s*\d+\s*个程序)")),
+    ("site/pages/home.zh.md", re.compile(
+        r"\d+\s*个(?:差分|对拍)?语料(?:程序|入口)")),
+)
+
+BINARY_SIZE_LITERAL = re.compile(
+    r"\b\d+(?:\.\d+)?\s*(?:KiB|MiB|GiB|KB|MB|GB)\b", re.I)
+TOOLCHAIN_ARTIFACT_SECTIONS = (
+    ("README.md", "Two different things are called \"native\""),
+    ("README.md", "The road without a JVM"),
+    ("README.zh-CN.md", "两样东西都叫「native」"),
+    ("README.zh-CN.md", "不装 JVM 的那条路"),
 )
 
 # The install instructions download release assets by name, and the release
@@ -1854,6 +1885,21 @@ def repository_contract_problems(files: dict[str, str]) -> tuple[list[str], int]
                 bad.append(f"{rel}: active introduction contains {name}")
             else:
                 seen += 1
+
+    for rel, pattern in OUTWARD_CORPUS_COUNTS:
+        if pattern.search(files[rel]):
+            bad.append(f"{rel}: outward copy contains a volatile differential-corpus count")
+        else:
+            seen += 1
+
+    for rel, heading in TOOLCHAIN_ARTIFACT_SECTIONS:
+        section = markdown_section(files[rel], heading)
+        if section is None:
+            bad.append(f"{rel}: missing toolchain section {heading!r}")
+        elif BINARY_SIZE_LITERAL.search(normalize_prose(section)):
+            bad.append(f"{rel}: {heading} contains a volatile binary size")
+        else:
+            seen += 1
 
     package = files["docs/package-design.md"]
     lock = markdown_section(package, "4.6 `dawn.lock` schema 1 冻结 Java 依赖闭包")
@@ -2026,6 +2072,24 @@ def check_repository_contracts_selftest() -> tuple[list[str], int]:
     if not any("active introduction contains volatile" in problem for problem in bad):
         return ["repository policy self-test: a volatile metric in the active intro stayed green"], 0
 
+    corpus_count = dict(files)
+    corpus_count["README.md"] += "\n59 corpus programs are compiled on both backends.\n"
+    bad, _ = repository_contract_problems(corpus_count)
+    if not any("volatile differential-corpus count" in problem for problem in bad):
+        return ["repository policy self-test: a volatile corpus count stayed green"], 0
+
+    binary_size = dict(files)
+    toolchain_heading = "The road without a JVM"
+    toolchain_section = markdown_section(binary_size["README.md"], toolchain_heading)
+    if toolchain_section is None:
+        return ["repository policy self-test: binary-size section fixture is absent"], 0
+    changed = toolchain_section + "\nThe native compiler is about 3.6 MB.\n"
+    binary_size["README.md"] = binary_size["README.md"].replace(
+        toolchain_section, changed, 1)
+    bad, _ = repository_contract_problems(binary_size)
+    if not any("volatile binary size" in problem for problem in bad):
+        return ["repository policy self-test: a volatile binary size stayed green"], 0
+
     active_lock = dict(files)
     lock_heading = "4.6 `dawn.lock` schema 1 冻结 Java 依赖闭包"
     lock_section = markdown_section(active_lock["docs/package-design.md"], lock_heading)
@@ -2062,7 +2126,7 @@ def check_repository_contracts_selftest() -> tuple[list[str], int]:
     bad, _ = repository_contract_problems(historical)
     if bad:
         return [f"repository policy self-test: scoped historical prose was rejected: {bad[0]}"], 0
-    return [], 10
+    return [], 12
 
 
 def read_audit_details() -> dict[str, str]:

--- a/scripts/spike-native/run.sh
+++ b/scripts/spike-native/run.sh
@@ -318,9 +318,9 @@ work="$(mktemp -d)"
 mkdir -p "$work/logs"
 
 # Whether this machine's cc can build with AddressSanitizer. Probed once,
-# because a corpus of 23 programs would otherwise ask 23 times, and reported
-# as `blocked` rather than as a failure: a missing sanitizer is no evidence
-# either way.
+# because a full run would otherwise ask once per corpus entry, and reported as
+# `blocked` rather than as a failure: a missing sanitizer is no evidence either
+# way.
 asan_ok=1
 printf 'int main(void){return 0;}\n' >"$work/asan_probe.c"
 if ! "$cc_bin" -fsanitize=address -o "$work/asan_probe" "$work/asan_probe.c" \

--- a/site/pages/home.md
+++ b/site/pages/home.md
@@ -55,7 +55,7 @@ Two backends, one answer
 
 ## feature-parity-body
 
-JVM bytecode and C (handed on to `cc`) are **peer** roads. Wherever divergence would be easiest, the language owns the thing itself: `Float` rendering is Schubfach in pure Dawn, the Unicode case tables belong to the compiler, `Map` iteration order is pinned to insertion. 59 corpus programs are compiled and run on both sides on every push, comparing stdout, stderr and exit code — a divergence is a red build.
+JVM bytecode and C (handed on to `cc`) are **peer** roads. Wherever divergence would be easiest, the language owns the thing itself: `Float` rendering is Schubfach in pure Dawn, the Unicode case tables belong to the compiler, `Map` iteration order is pinned to insertion. The differential corpus is compiled and run on both sides on every push, comparing stdout, stderr and exit code — a divergence is a red build.
 
 ## closing
 

--- a/site/pages/home.zh.md
+++ b/site/pages/home.zh.md
@@ -1,4 +1,4 @@
-<!-- doc-check: translation-of site/pages/home.md @ b11ca79412effde5 -->
+<!-- doc-check: translation-of site/pages/home.md @ 498aa209aedf86bd -->
 
 # 首页文案 —— 中文译本
 
@@ -50,7 +50,7 @@ type · match · effect · !io
 
 ## feature-parity-body
 
-JVM 字节码与 C（再交给 `cc`）是**平级**的两条路。最容易分叉的地方语言自己拥有：`Float` 渲染是纯 Dawn 的 Schubfach、Unicode 大小写表是编译器的、`Map` 迭代顺序按插入定死。59 个语料程序每次 push 两边编两边跑，比 stdout、stderr、退出码——分歧会红灯。
+JVM 字节码与 C（再交给 `cc`）是**平级**的两条路。最容易分叉的地方语言自己拥有：`Float` 渲染是纯 Dawn 的 Schubfach、Unicode 大小写表是编译器的、`Map` 迭代顺序按插入定死。整套差分语料每次 push 两边编两边跑，比 stdout、stderr、退出码——分歧会红灯。
 
 ## closing
 


### PR DESCRIPTION
## What

- Replace exact native differential corpus counts in the README and site copy with stable descriptions.
- Remove exact executable sizes from the toolchain walkthrough.
- Extend the existing repository-policy contract and its negative controls so those volatile figures cannot silently return.
- Remove the stale 23-program count from the differential harness comment.

## Why

The outward copy still said 59 corpus programs, while the harness now discovers 107 entries (100 single files and seven projects). The v0.68.0 native release asset is also 5,764,136 bytes rather than the documented ~3.6 MB, and the GraalVM example size varies with the toolchain. These figures do not change a reader decision, but they force multiple translations to decay whenever the corpus or build changes—the same failure mode GOV-11 already guards against in the README introduction.

## Validation

- repository policy contracts: 47 checks
- repository policy negative controls: 12 checks
- translation pairs: 7 checks
- `bash -n scripts/spike-native/run.sh`
- `git diff --check`