### PR TITLE
Honor ZIP output limits for stored entries

### DIFF
--- a/packages/inflate/src/zip.dawn
+++ b/packages/inflate/src/zip.dawn
@@ -283,6 +283,29 @@ pub fn read_bounded(src: Bytes, m: Meta, cap: Option[Int]) -> Result[Bytes, Stri
   if not in_range(src, start, m.csize) {
     return Err("zip: entry data runs past the end: " ++ m.name)
   }
+  # A stored member's compressed bytes are its output. Check both metadata
+  # claims, and the caller's ceiling, before slicing those bytes out of the
+  # archive; doing either afterwards has already paid the allocation the
+  # ceiling exists to prevent.
+  if m.method == METHOD_STORED {
+    if m.csize != m.size {
+      return Err("zip: " ++ m.name ++ " unpacked to " ++ to_string(m.csize) ++
+          " bytes, the directory says " ++ to_string(m.size))
+    }
+    match cap {
+      None -> { }
+      Some(lim) -> {
+        if lim < 0 {
+          return Err("zip: " ++ m.name ++ ": a negative output limit (" ++
+              to_string(lim) ++ ")")
+        }
+        if m.size > lim {
+          return Err("zip: " ++ m.name ++ ": the output exceeds the " ++
+              to_string(lim) ++ " byte limit (stopped at 0 bytes)")
+        }
+      }
+    }
+  }
   let raw = bytes.slice(src, start, start + m.csize)
   var out = raw
   if m.method == METHOD_DEFLATE {
@@ -376,4 +399,46 @@ test "overflowing zip64 metadata is refused instead of wrapping into range" {
     Ok(Ok(_)) -> { assert false }
     Err(_) -> { assert false }
   }
+}
+
+test "stored entries honor the output ceiling before their bytes are copied" {
+  # A minimal local header followed by one stored byte.
+  var raw = bytes.buf()
+  for x in [0x50, 0x4B, 0x03, 0x04] { raw = bytes.put(raw, x) }
+  while bytes.size(raw) < 30 { raw = bytes.put(raw, 0) }
+  raw = bytes.put(raw, 120)
+  let src = bytes.freeze(raw)
+  let payload = bytes.utf8("x")
+  let stored = Meta {
+    name: "stored",
+    is_dir: false,
+    flags: 0,
+    method: METHOD_STORED,
+    crc: crc32.sum(payload),
+    csize: 1,
+    size: 1,
+    local: 0,
+  }
+
+  assert read_bounded(src, stored, Some(1)) == Ok(payload)
+  assert read_bounded(src, stored, Some(0)) ==
+    Err("zip: stored: the output exceeds the 0 byte limit (stopped at 0 bytes)")
+  assert read_bounded(src, stored, Some(-1)) ==
+    Err("zip: stored: a negative output limit (-1)")
+
+  # This claim used to be checked only after the compressed byte had
+  # already been sliced out. A stored member cannot legitimately have
+  # different compressed and uncompressed sizes.
+  let inconsistent = Meta {
+    name: "inconsistent",
+    is_dir: false,
+    flags: 0,
+    method: METHOD_STORED,
+    crc: 0,
+    csize: 1,
+    size: 0,
+    local: 0,
+  }
+  assert read_bounded(src, inconsistent, Some(0)) ==
+    Err("zip: inconsistent unpacked to 1 bytes, the directory says 0")
 }

--- a/scripts/core-golden/selfhost.norm.sha
+++ b/scripts/core-golden/selfhost.norm.sha
@@ -19,7 +19,7 @@ fd945a1f7288482ff730cd037e9c940952e239ce3ca79e34e52ce152153d3564  ./dawn$pkg$com
 98b828823caa43dbf3debdeeb0f9be1071dbbd21cc8beb5d02ffaa82a544253d  ./dawn$pkg$inflate.crc32.core
 7d03ffd50e7f6e49864239336824482895fd64317fe1ecef811cb5bb0ac50af4  ./dawn$pkg$inflate.deflate.core
 5861caa2f8bae247fca3015988977486f8f18dba05cdd7659d7306d0bfc89f92  ./dawn$pkg$inflate.gzip.core
-fe142c116739992becfa013cf05f524ebdb5445d7d79a68aa09e0b8fc271b2c6  ./dawn$pkg$inflate.zip.core
+2eca9f855b622e6fad184c7e77abc048d85db1b67690f7286498ba855484e0eb  ./dawn$pkg$inflate.zip.core
 f2d4777dbd277027c7d85f912bae29caf8d92c219d41dba13a38a9f3f55f4271  ./dawn$pkg$json2.lexer.core
 0d81711ec6c52eafac8f5b7a6574a3ba09e69898a556dc79d6319050506781ec  ./dawn$pkg$json2.parser.core
 2e0783ee56a8d11171bc670340d9a8a15c3d917b69a18b06eaf1af5d9ea922a9  ./dawn$pkg$json2.render.core

--- a/scripts/core-golden/selfhost.sha
+++ b/scripts/core-golden/selfhost.sha
@@ -19,7 +19,7 @@ d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$com
 98b828823caa43dbf3debdeeb0f9be1071dbbd21cc8beb5d02ffaa82a544253d  ./dawn$pkg$inflate.crc32.core
 7d03ffd50e7f6e49864239336824482895fd64317fe1ecef811cb5bb0ac50af4  ./dawn$pkg$inflate.deflate.core
 5861caa2f8bae247fca3015988977486f8f18dba05cdd7659d7306d0bfc89f92  ./dawn$pkg$inflate.gzip.core
-fe142c116739992becfa013cf05f524ebdb5445d7d79a68aa09e0b8fc271b2c6  ./dawn$pkg$inflate.zip.core
+2eca9f855b622e6fad184c7e77abc048d85db1b67690f7286498ba855484e0eb  ./dawn$pkg$inflate.zip.core
 f2d4777dbd277027c7d85f912bae29caf8d92c219d41dba13a38a9f3f55f4271  ./dawn$pkg$json2.lexer.core
 0d81711ec6c52eafac8f5b7a6574a3ba09e69898a556dc79d6319050506781ec  ./dawn$pkg$json2.parser.core
 2e0783ee56a8d11171bc670340d9a8a15c3d917b69a18b06eaf1af5d9ea922a9  ./dawn$pkg$json2.render.core
@@ -58,7 +58,7 @@ c1da51783bb4bc867d5ba841f62574789fdb69bcefd5bd962cae61ae4d2c01a9  ./jvm.ops.core
 a97cd6fbdaa8decda3fb655d1b37b10cdf7ddcaecb34764aab7f4e1035623c7f  ./jvm.rtclasses.core
 2103a2252c3781229ed03c8ac7ad1098a1afae2f440077db2c7f10e3585ec485  ./jvm.testrun.core
 b5c4273686aba70e0ae7b69c352a225b5a29ee12b66ddead9351ad999d31b80b  ./lsp.lspc.core
-1e4ec6078f10f8faf1613a622109025aea5af892e641b772f25574c71a23ef1c  ./lsp.lspq.core
+2a3cd5a9294b9b34d986bda2ddafebd2ea3fc0780d547793eda93f5635400f2d  ./lsp.lspq.core
 bd4b616965d5545d5de5beff49e2d45d0da8aacee74e317b6a322837755e55fa  ./lsp.server.core
 b2228245279f4a698ec410e5a20d7dcce25c3d2075bb6546e64a68a3a151d764  ./main.core
 36e87dca0697c2bad7ef02510dde1aae2be2b329f0b25d96971bc7b12b78a49d  ./nmain.core


### PR DESCRIPTION
## Problem

`read_bounded` enforced its output ceiling only when a member used DEFLATE. A stored member sliced all `csize` bytes first, ignored `cap`, and only afterwards noticed if its compressed and uncompressed size claims disagreed.

That let a malformed stored entry allocate beyond the caller budget before it was rejected.

## Fix

- Reject inconsistent stored size claims before slicing entry data.
- Reject negative stored-entry limits.
- Refuse a stored entry that exceeds its limit before copying any bytes.
- Cover the exact boundary, zero, negative, and inconsistent metadata cases.

## Validation

- `./bin/dawn test packages/inflate`
- `./bin/dawn test compiler-plan`
- `./bin/dawn test selfhost`
- `./bin/dawn fmt compiler-plan std site selfhost packages examples --check`
- `./scripts/inflate-contract/run.sh`
- `./scripts/selfhost-core-diff.sh`

The Core golden was re-recorded for the intended `inflate.zip` compiler-input change.
