### PR TITLE
Report retained JVM results before wasm builds

### DIFF
--- a/scripts/wasm-dom-contract/retained.sh
+++ b/scripts/wasm-dom-contract/retained.sh
@@ -181,6 +181,15 @@ if ! run_jvm "$root" "$work/jvm.txt"; then
   cat "$work/jvm.err" >&2
   exit 1
 fi
+if [ "$record" -eq 0 ]; then
+  if ! cmp -s "$expected" "$work/jvm.txt"; then
+    echo "FAIL: retained JVM session changed:" >&2
+    diff -u "$expected" "$work/jvm.txt" | head -40 >&2
+    exit 1
+  fi
+  echo "OK   retained JVM: 9 lines in one process, byte for byte"
+fi
+
 if ! build_wasm "$root" "$work/base.wasm"; then
   echo "FAIL: retained wasm fixture did not build:" >&2
   cat "$work/wasm-build.err" >&2
@@ -203,12 +212,6 @@ if [ "$record" -eq 1 ]; then
   exit 0
 fi
 
-if ! cmp -s "$expected" "$work/jvm.txt"; then
-  echo "FAIL: retained JVM session changed:" >&2
-  diff -u "$expected" "$work/jvm.txt" | head -40 >&2
-  exit 1
-fi
-echo "OK   retained JVM: 9 lines in one process, byte for byte"
 if ! cmp -s "$expected" "$work/wasm.txt"; then
   echo "FAIL: retained wasm session changed:" >&2
   diff -u "$expected" "$work/wasm.txt" | head -40 >&2


### PR DESCRIPTION
## What

- compare the ordinary JVM retained transcript with its golden immediately after `run_jvm`
- report the completed C and JVM halves before the first wasm toolchain invocation
- preserve `--record`: it still waits for byte-identical JVM/wasm output before replacing the golden
- leave the JVM-vs-wasm cross-check after `run_wasm`

## Verification

- a failing `dawnc` shim simulating an absent wasm toolchain reports seam, C, and JVM success before the wasm build failure
- a node wrapper that perturbs otherwise-successful wasm output turns the JVM-vs-wasm cross-check red
- full retained contract with clang-20, including both production mutants
- `--record` with unchanged golden digest
- Bash syntax, ShellCheck, and diff checks

Closes #36