### PR TITLE
Include full path, observed size, and limit in oversized-sample error

### DIFF
--- a/playground/deploy/lsp-measure.py
+++ b/playground/deploy/lsp-measure.py
@@ -1170,7 +1170,7 @@ def load_samples(sample_dir: Path) -> list[tuple[str, str]]:
             ) from error
         if len(raw) > SOURCE_LIMIT_BYTES:
             raise MeasurementError(
-                f"sample {path.name} exceeds the Playground source limit"
+                f"sample {path} exceeds the Playground source limit, {len(raw)} is greater than {SOURCE_LIMIT_BYTES}"
             )
         samples.append((name, source))
     return samples


### PR DESCRIPTION
Fixes #28. Changed the oversized-sample error at lsp-measure.py:1173 to include the full path (previously just the filename), plus the observed byte count and the configured limit — matching the style of the sibling error above it. No test references the old message text (confirmed via repo-wide search). Verified by manually triggering the error path with an oversized sample file — correct path, byte count, and limit all appear in the message