### PR TITLE
Preserve binary content in the in-memory filesystem

### DIFF
--- a/scripts/core-golden/selfhost.norm.sha
+++ b/scripts/core-golden/selfhost.norm.sha
@@ -13,7 +13,7 @@ f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.c
 2c831a420d5abcf1678aa8aa7eb52d292b6f5521a28f85d89087731e0bb4464e  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 8c3a3b22c355c97a4411a6600b234839a9e77c570de75b58067f0c265079289e  ./dawn$pkg$compiler_plan.envmem.core
-c44d5c4d245553f9a99057b3c0d106817ca44e6eb895ff45dab1851a400eb8c9  ./dawn$pkg$compiler_plan.exitmem.core
+f00b599e8154776bc98871d5b949efeb8d9943cf77ff8dc223b49cf7fc393b01  ./dawn$pkg$compiler_plan.exitmem.core
 1a7f20bda7115aa2a612a657354c451e7aa9a34218758ea9e66cf4f6870dca5c  ./dawn$pkg$compiler_plan.manifestv.core
 621cd31649cc1187fc4f6a9d0c35cd773464c2fec6ecf25eaf2bebb7ac134f16  ./dawn$pkg$compiler_plan.pkgfetch.core
 ccd13d23ac24519c19ea384cb80b51978642efd76d92c928d1585096fdb05762  ./dawn$pkg$compiler_plan.procmem.core
@@ -32,7 +32,7 @@ ffdc027b1c53e03551e867d47de472a6b7084b8db96051829912ed76aa02e216  ./dawn$pkg$sha
 de72b0a760ab9d0fabf6a8efcee97555e23baef075eab4f04571f35391192114  ./doc.core
 52d8143c338b69518f1ca75aa936f5752cf15896aa9cb18c0a83805f6e411443  ./driver.analyze.core
 eeb8923f514acdf745419c3715a18b1ffa3b32919d92441996dfac199d7795d8  ./driver.checkdump.core
-21ba40930ca744902667c9d9c23eee270cefe965ce16f370c5580219aa689bbb  ./driver.fsmem.core
+f53cdd7f47b5140a565bd80de093cd4470600694eed7ff37210510a31598a846  ./driver.fsmem.core
 5fb4b56db781bc2310c4baef1f34c8bd53b0e2272288191d6b3cbd19993b9041  ./driver.stdlib.core
 1a8b40fbfce7303b2117262aa453a7e1b0866602a2ac1569db9041b2de6f57ea  ./embed.rtsrc.core
 453a361a73aa5e01bd9c71b49bfe95112b0322476862069d726250a42f34a740  ./embed.stdsrc.core

--- a/scripts/core-golden/selfhost.sha
+++ b/scripts/core-golden/selfhost.sha
@@ -10,10 +10,10 @@ a7827c78e9e6e871210a4833fd36bfe97f799e37451121d965691731b90dcba1  ./check.exhaus
 24a4905110d031256455d0eb03a1e637a9e0335796fa4746d965ebf99d3e9784  ./check.passes.core
 f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.core
 8849bed0d19486afa45ea6ab360255cc02eed4aa063b42e319c3a99f67db37f4  ./check.types.core
-6ecd8f305502d90e39c76c7c8efeee0339e9458d8fe344f07f4b6aaa32e0f4dd  ./dawn$pkg$compiler_plan.consolemem.core
+bc8975320843cf7454ed6a22e2bf8d2781a3f3db30430b299ef182be4685b28e  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 8c3a3b22c355c97a4411a6600b234839a9e77c570de75b58067f0c265079289e  ./dawn$pkg$compiler_plan.envmem.core
-c44d5c4d245553f9a99057b3c0d106817ca44e6eb895ff45dab1851a400eb8c9  ./dawn$pkg$compiler_plan.exitmem.core
+f00b599e8154776bc98871d5b949efeb8d9943cf77ff8dc223b49cf7fc393b01  ./dawn$pkg$compiler_plan.exitmem.core
 eebd72c568e3a6f4bb34442d9eb131f3c7849dc669bcaa6e0982708ded453c44  ./dawn$pkg$compiler_plan.manifestv.core
 621cd31649cc1187fc4f6a9d0c35cd773464c2fec6ecf25eaf2bebb7ac134f16  ./dawn$pkg$compiler_plan.pkgfetch.core
 ccd13d23ac24519c19ea384cb80b51978642efd76d92c928d1585096fdb05762  ./dawn$pkg$compiler_plan.procmem.core
@@ -32,7 +32,7 @@ ffdc027b1c53e03551e867d47de472a6b7084b8db96051829912ed76aa02e216  ./dawn$pkg$sha
 de72b0a760ab9d0fabf6a8efcee97555e23baef075eab4f04571f35391192114  ./doc.core
 bbac62d6a7a91c86e41c1b7ffbd24ec9c0cbd8a2f072fa2f485960654bb69816  ./driver.analyze.core
 eeb8923f514acdf745419c3715a18b1ffa3b32919d92441996dfac199d7795d8  ./driver.checkdump.core
-21ba40930ca744902667c9d9c23eee270cefe965ce16f370c5580219aa689bbb  ./driver.fsmem.core
+f53cdd7f47b5140a565bd80de093cd4470600694eed7ff37210510a31598a846  ./driver.fsmem.core
 3b9bffe01af7fff6f17436d92a2d105dad4a5192cea2bd8fe4b3dcb8364c0694  ./driver.stdlib.core
 1a8b40fbfce7303b2117262aa453a7e1b0866602a2ac1569db9041b2de6f57ea  ./embed.rtsrc.core
 453a361a73aa5e01bd9c71b49bfe95112b0322476862069d726250a42f34a740  ./embed.stdsrc.core
@@ -63,7 +63,7 @@ c1da51783bb4bc867d5ba841f62574789fdb69bcefd5bd962cae61ae4d2c01a9  ./jvm.ops.core
 624f4a653ab99dc6f26a42205a3cf2f199848e74f901f40f64375ff1de75ca94  ./jvm.rtclasses.core
 2103a2252c3781229ed03c8ac7ad1098a1afae2f440077db2c7f10e3585ec485  ./jvm.testrun.core
 16b0c299e25a6be9f820226a9f27d1e763f966e9e4cd5d4d0d6df04039b12ac3  ./lsp.lspc.core
-431f36ec0744c7951e9182698a0edab1ef41e9d4ca39400237002e80661b5412  ./lsp.lspq.core
+f228dbfdee73b003b8bc34f6290276ad0558654c767f3001cb074150d23d00cb  ./lsp.lspq.core
 ec1eca7da3c15a8b3c5702075df92cbc98213b1adbfce7d30aa10eb1ec02ba8a  ./lsp.server.core
 fb93c4440aaa4d32c4966f73dcfee9297b53d1eca11504dae649d1a76d82d90e  ./main.core
 b3e48f6df5fa2217f4050296e7f8baa7585d8a24fc559d09374a3a3dbd9c745f  ./nmain.core

--- a/selfhost/src/driver/fsmem.dawn
+++ b/selfhost/src/driver/fsmem.dawn
@@ -15,6 +15,8 @@
 # `list_names` answer what the real file system would answer for the same tree.
 # Paths are normalized against the base directory the caller names at
 # construction: nothing here reads the host, not even for the current directory.
+# Files hold bytes so binary writes survive unchanged. Only text-facing
+# operations encode or decode UTF-8; reading text never changes the stored bytes.
 
 use std/io
 use std/io.{Fs, Deleted, NotFound}
@@ -30,7 +32,7 @@ use fspath/fspath
 ## counter `temp_dir` / `temp_file` hand out names from.
 pub type MemFs = {
   base: String,
-  files: Map[String, String],
+  files: Map[String, Bytes],
   dirs: Map[String, Bool],
   seq: Int
 }
@@ -92,7 +94,7 @@ fn child_names(st: MemFs, k: String) -> List[String] = {
   sort(names)
 }
 
-fn mem_read(st: MemFs, p: String) -> Result[String, ForeignError] = {
+fn mem_read(st: MemFs, p: String) -> Result[Bytes, ForeignError] = {
   let k = key(st, p)
   match map.get(st.files, k) {
     Some(t) -> Ok(t)
@@ -113,7 +115,7 @@ fn mem_mkdirs(st: MemFs, p: String) -> (MemFs, Result[Unit, ForeignError]) = {
   (MemFs { ..st, dirs: map.insert(with_ancestors(st.dirs, k), k, true) }, Ok(()))
 }
 
-fn mem_write(st: MemFs, p: String, content: String) -> (MemFs, Result[Unit, ForeignError]) = {
+fn mem_write(st: MemFs, p: String, content: Bytes) -> (MemFs, Result[Unit, ForeignError]) = {
   let k = key(st, p)
   if is_dir_key(st, k) {
     return (st, Err(ferr("is_a_directory", "a directory is in the way", k)))
@@ -145,10 +147,10 @@ fn mem_rename(st: MemFs, src: String, dst: String) -> (MemFs, Result[Unit, Forei
   let s = key(st, src)
   let d = key(st, dst)
   match map.get(st.files, s) {
-    Some(text) ->
+    Some(content) ->
       return (MemFs {
         ..st,
-        files: map.insert(map.remove(st.files, s), d, text),
+        files: map.insert(map.remove(st.files, s), d, content),
         dirs: with_ancestors(st.dirs, d)
       }, Ok(()))
     None -> ()
@@ -161,8 +163,8 @@ fn mem_rename(st: MemFs, src: String, dst: String) -> (MemFs, Result[Unit, Forei
   var dirs = st.dirs
   for f in map.keys(st.files) {
     if str.starts_with(f, prefix) {
-      let text = map.get(st.files, f).expect("moved file")
-      files = map.insert(map.remove(files, f), d ++ str.drop(f, str.len(s)), text)
+      let content = map.get(st.files, f).expect("moved file")
+      files = map.insert(map.remove(files, f), d ++ str.drop(f, str.len(s)), content)
     }
   }
   for g in map.keys(st.dirs) {
@@ -185,7 +187,7 @@ fn mem_temp(
   let path = dir ++ "/" ++ prefix ++ to_string(st.seq)
   let bumped = MemFs { ..st, seq: st.seq + 1 }
   let (next, made) =
-    if as_dir { mem_mkdirs(bumped, path) } else { mem_write(bumped, path, "") }
+    if as_dir { mem_mkdirs(bumped, path) } else { mem_write(bumped, path, bytes.utf8("")) }
   match made {
     Ok(_) -> (next, Ok(path))
     Err(e) -> (st, Err(e))
@@ -214,13 +216,17 @@ pub fn mem_empty(base: String) -> MemFs =
 
 ## `st` with one more file in it; the directories above it come along.
 pub fn mem_put(st: MemFs, path: String, content: String) -> MemFs = {
-  let (next, _) = mem_write(st, path, content)
+  let (next, _) = mem_write(st, path, bytes.utf8(content))
   next
 }
 
-## What the table holds at `path`, or `None` when nothing is there.
+## The file at `path` as UTF-8 text, or `None` when nothing is there.
+## Malformed sequences are replaced, just as in the text-reading handler arm.
 pub fn mem_content(st: MemFs, path: String) -> Option[String] =
-  map.get(st.files, key(st, path))
+  match map.get(st.files, key(st, path)) {
+    Some(content) -> Some(bytes.decode_utf8_lossy(content))
+    None -> None
+  }
 
 ## Every file path in the table, sorted. Directories are not listed: they are
 ## implied by these.
@@ -281,18 +287,18 @@ pub fn with_fs_mem[T](seed: MemFs, body: fn() -> T !Fs !io) -> (T, MemFs) !io = 
       st = next
       r
     }
-    fs_read_file(path) => mem_read(st, path)
+    fs_read_file(path) => match mem_read(st, path) {
+      Ok(content) -> Ok(bytes.decode_utf8_lossy(content))
+      Err(e) -> Err(e)
+    }
     fs_write_file(path, content) => {
-      let (next, r) = mem_write(st, path, content)
+      let (next, r) = mem_write(st, path, bytes.utf8(content))
       st = next
       r
     }
-    fs_read_bytes(path) => match mem_read(st, path) {
-      Ok(t) -> Ok(bytes.utf8(t))
-      Err(e) -> Err(e)
-    }
+    fs_read_bytes(path) => mem_read(st, path)
     fs_write_bytes(path, content) => {
-      let (next, r) = mem_write(st, path, bytes.decode_utf8_lossy(content))
+      let (next, r) = mem_write(st, path, content)
       st = next
       r
     }
@@ -383,6 +389,33 @@ test "the table answers the operations the way the tree implies" {
   assert mem_content(table, "/t/sub/a.txt") == Some("alpha")
   let gone: Option[String] = None
   assert mem_content(table, "/t/c.txt") == gone
+}
+
+test "binary files survive writes, renames, and a new handler" {
+  let payload = bytes.from_hex("fffe0080c080f09f8c85").expect("binary fixture")
+  let (_, table) = with_fs_mem(mem_empty(MEM_BASE), () => {
+    assert ok(io.write_bytes("bin/payload", payload))
+    assert io.read_bytes("bin/payload") == Ok(payload)
+    assert ok(io.rename("bin/payload", "bin/moved"))
+    assert ok(io.rename("bin", "archive"))
+    assert io.read_bytes("archive/moved") == Ok(payload)
+  })
+  let (_, _) = with_fs_mem(table, () => {
+    assert io.read_bytes("archive/moved") == Ok(payload)
+  })
+}
+
+test "text and byte operations share one UTF-8 file" {
+  let text = "hello \u{4e16}\u{754c}\u{0}"
+  let seed = mem_put(mem_empty(MEM_BASE), "seed", text)
+  let (_, table) = with_fs_mem(seed, () => {
+    assert io.read_bytes("seed") == Ok(bytes.utf8(text))
+    assert ok(io.write_bytes("text", bytes.utf8(text)))
+    assert io.read_file("text") == Ok(text)
+    assert ok(io.write_file("text", text ++ "!"))
+    assert io.read_bytes("text") == Ok(bytes.utf8(text ++ "!"))
+  })
+  assert mem_content(table, "text") == Some(text ++ "!")
 }
 
 test "the mounted std is the embedded std, and nothing else is there" {


### PR DESCRIPTION
`MemFs` decoded every binary write as UTF-8, replacing malformed bytes before a later binary read. Store bytes directly and encode/decode only for text operations, preserving the existing text helper and constructor signatures.

Regression coverage includes `FF FE 00`, invalid UTF-8, file and subtree renames, reuse of the returned filesystem, and text/byte interoperability. With the original storage and the new tests, exactly the binary round-trip test fails; with the fix, all 595 selfhost tests pass.

Validation: formatter; official Core `--record` and `--check` (17 dumps, 87 module hashes); true-parent/current compiler comparison of the same selfhost corpus (1811 byte-identical classes, no new `Emit-Change` declaration). The accompanying Core hashes include generated ID shifts in consolemem/lspq and matching exitmem handler-marker literals; no golden files were hand-edited.

Closes #65.
