### PR TITLE
Propagate JVM statement fallthrough through blocks

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -731,7 +731,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # The classfile gate's thirteen compiling Never mutants (TEST-01's call and
+  # The classfile gate's fourteen compiling Never mutants (TEST-01's call and
   # adapter termination assertions), moved whole out of `contracts` (#299):
   # at ~14s a mutant the block was ~180s of that job's classfile step and
   # shares nothing with the corpus loop but the javac'd Verify classes, which

--- a/docs/never-return-design.md
+++ b/docs/never-return-design.md
@@ -71,3 +71,27 @@ closure 的 erased `apply` 和 SAM bridge 在 verifier 看来返回 `Object`。�
 - 不修改 `io.exit`，也不把宿主的 `System.exit` ABI 变成语言 bottom 契约。
 - 不碰 SEM-04，也不顺带修改 Cursor 表示。
 - 不用 `Emit-Change(emit selfhost)` 声明。gate-map 已证明该 oracle 对 selfhost 源码改动不可见。
+
+## 七、2026-09-07：语句不落返的传播
+
+复核发现 `let y: Int = stop(); println(y)` 的检查通过，但 JVM 编译器报
+`symbol has no slot`；列表元素中的 stop/return 也可触发。`CSLet` 在初始化不落返时
+不分配 slot 是正确的，错误是 `gen_cstmt` 丢掉了这个结论，`CBlock` 继续发射后续读 y。
+
+修复使语句发射与表达式一样返回 `(Gen, falls)`。let、assign、discard、if 传播该位，
+block 在第一条不落返语句后停止，既不发射后续语句也不发射尾值。if 的条件不落返也须
+立即返回。循环仍保守认为可落返：body 不落返可能只是 break/continue，step 仍是
+continue 的目标，不能因此删掉 step 或循环后的路径。CSDrop 在 JVM 是可落返的空操作。
+
+回归覆盖直接初始化、列表首/非首元素、两支终止、嵌套块、赋值/discard/if、return、
+break/continue 和仍可落返的负控。双后端输出为独立手写期望；编译可通过的 block
+传播反转变异体必须使 owning regression 失败。Core 语义不变，只按惯例重录编译器
+自身的 Core 哈希；不得用未声明的 emit 差异掩盖已有语料的变化。
+
+本次不改变 Never 的可书写位置，不做通用 CFG/DCE，也不重构所有实参发射入口。
+
+实现后的 613 项 selfhost 测试及 14 个 compiling Never 变异体通过，新增变异体只使
+`NEVER_STATEMENT_FLOW` 失败。旧 release emit 差分通过；Core 文本语料不变，自身哈希
+变动已重录。native ASan 另发现列表元素跳出/抛错会泄漏内部数组（#94）：本项的
+双后端语料跑列表的未取分支（仍要求 JVM 编译其全部代码），classfile 探针另跑取分支；
+取分支的 native 内存验收由 #94 补齐，不加 known-red 豁免。

--- a/scripts/classfile-verify/run.sh
+++ b/scripts/classfile-verify/run.sh
@@ -54,7 +54,7 @@
 # Modes, for CI scheduling and nothing else (the 2026-08-20 job split):
 #
 #   run.sh                          # everything, the local default
-#   run.sh --never-mutants-only     # the 13 compiling Never mutants + probe
+#   run.sh --never-mutants-only     # the 14 compiling Never mutants + probes
 #   run.sh --without-never-mutants  # selftest, corpus verify, corpus mutant,
 #                                   # constant-pool scan
 #
@@ -169,6 +169,22 @@ expect_never_marker() {
 run_never_mutants() {
 
 python3 "$never_probe" "$root/build/dawn-selfhost.jar" "$work"
+
+python3 scripts/classfile-verify/statement_probe.py "$root/build/dawn-selfhost.jar" "$work"
+new_never_mutant omit-statement-fallthrough
+replace_never_once "$never_mutant/selfhost/src/jvm/emit.dawn" \
+  '        if not stmt_falls { return (g1, false) }' \
+  '        if false { return (g1, false) }'
+build_never_mutant omit-statement-fallthrough
+if python3 scripts/classfile-verify/statement_probe.py "$never_mutant/compiler.jar" "$work" \
+    > "$never_mutant/probe.out" 2>&1; then
+  never_die "statement fallthrough mutant stayed green"
+fi
+if ! grep -qx 'ASSERT: NEVER_STATEMENT_FLOW' "$never_mutant/probe.out"; then
+  cat "$never_mutant/probe.out" >&2
+  never_die "statement fallthrough mutant missed its owning assertion"
+fi
+echo "PASS  statement fallthrough mutant compiles, then fails NEVER_STATEMENT_FLOW"
 
 new_never_mutant reject-wide-sam-bottom
 replace_never_once "$never_mutant/selfhost/src/check/checker.dawn" \

--- a/scripts/classfile-verify/statement_probe.py
+++ b/scripts/classfile-verify/statement_probe.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Hold statement fallthrough to real emitted classes, not source spelling."""
+import sys
+import tempfile
+from pathlib import Path
+
+from never_probe import ADD_EXPORTS, ROOT, compiler_command, run
+
+
+def main():
+    jar = Path(sys.argv[1]).resolve()
+    verifier = Path(sys.argv[2]).resolve()
+    source = ROOT / 'scripts/spike-native/never_statements.dawn'
+    expected = source.with_suffix('.expect').read_text()
+    checked = run(compiler_command(jar, 'check', str(source)))
+    if checked.returncode:
+        raise RuntimeError('statement fixture did not check: ' + checked.stderr)
+    with tempfile.TemporaryDirectory(prefix='dawn-statement-flow-') as temp:
+        out = Path(temp)
+        emitted = run(compiler_command(jar, '__emit', str(source), '-o', str(out)))
+        if emitted.returncode:
+            if 'has no slot' not in emitted.stderr + emitted.stdout:
+                raise RuntimeError('unexpected emission failure: ' + emitted.stderr + emitted.stdout)
+            print('ASSERT: NEVER_STATEMENT_FLOW')
+            return 1
+        verified = run(['java', *ADD_EXPORTS, '-cp', f'{verifier}:{jar}', 'Verify', str(out)])
+        if verified.returncode:
+            raise RuntimeError('statement class verification failed: ' + verified.stderr + verified.stdout)
+        executed = run(['java', *ADD_EXPORTS, '-cp', str(out), 'never_statements'])
+        if executed.returncode or executed.stdout != expected or executed.stderr:
+            print('ASSERT: NEVER_STATEMENT_FLOW')
+            print(executed.stdout + executed.stderr)
+            return 1
+        taken = run(['java', *ADD_EXPORTS, '-cp', str(out), 'never_statements', 'take-lists'])
+        taken_expected = expected.replace('21\n22\n', 'stop\nstop\n')
+        if taken.returncode or taken.stdout != taken_expected or taken.stderr:
+            print('ASSERT: NEVER_STATEMENT_FLOW')
+            print(taken.stdout + taken.stderr)
+            return 1
+    print('classfile statement fallthrough contract: OK')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/core-golden/selfhost.norm.sha
+++ b/scripts/core-golden/selfhost.norm.sha
@@ -13,7 +13,7 @@ f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.c
 bd3e7cff7551fe9f7ade694dc9612df8d1c623590098ed95ffbf49f62bb54ba5  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-d82e9e09677355fcef122d6729465a886b2698031da94929d5fed97f84364862  ./dawn$pkg$compiler_plan.exitmem.core
+32298f6375d942764ba227edd7cca18becb8312d107f38143fafc339dd714dfa  ./dawn$pkg$compiler_plan.exitmem.core
 1a7f20bda7115aa2a612a657354c451e7aa9a34218758ea9e66cf4f6870dca5c  ./dawn$pkg$compiler_plan.manifestv.core
 0699a9028c3f19a3ca61dc8e676a3bbc3afd067e4cfc3158cad3efa3941a7e64  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core
@@ -54,7 +54,7 @@ ea161d1de7c93f569e4cd223c16e5d22aa22161e6f3784f4c721aae789f9cc48  ./front.token.
 e3625afb4eb65f86eac78b85a2c06f9feb63eba32f5d783d9299762289825de8  ./ir.lower.core
 4fdb14327a6a1032b4e6cc16dffdc234fc94451afa38fe9b0a6faaefade9ba00  ./ir.reach.core
 aca1eb870fba25749b6cdb58d4025bdf5e94abd92f943325176501c2f57dd877  ./jvm.codegen.core
-b235bbdbd26c8dbcde016b6da28ee6183fc84dd545ab10cfe7528295046580b7  ./jvm.emit.core
+3151cfba15a0932307fce4af81d8211c75e994f589525c10ed80ff577b7a4cff  ./jvm.emit.core
 4633c5b4554ca7da812ee16dab2aa85d4c42547b497dca9c51438cc22d71c1f7  ./jvm.help.core
 4f883016c24fbe233779062cf7dac82a35ecc42135d425114f7cb22b534acb9c  ./jvm.jarw.core
 70338f60c462b694a9514f1f6ab90c8b4721e2406b86c008554bc7c3999a7540  ./jvm.jfold.core

--- a/scripts/core-golden/selfhost.sha
+++ b/scripts/core-golden/selfhost.sha
@@ -10,10 +10,10 @@ bc388f7f4c447bdc1ccef34b77cc62779bf3e3f72ea2a09082d62a4e442bdb39  ./c.ctestrun.c
 59bc4532c55820ca4253b404d97f027c695cd63adc048822cf6844c1779cc7c0  ./check.passes.core
 f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.core
 6fc9306097366f30a33a372afa51cce13550764098465c356fd27ca9d05217ec  ./check.types.core
-aed74f8f74dd88369431c199223431cc8c6f76ddf9d528031da8408f0a9f5525  ./dawn$pkg$compiler_plan.consolemem.core
+accce79980f699ec6caec3f487f1374bff8e711f33bba84b517cd89cf8fc4656  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-d82e9e09677355fcef122d6729465a886b2698031da94929d5fed97f84364862  ./dawn$pkg$compiler_plan.exitmem.core
+32298f6375d942764ba227edd7cca18becb8312d107f38143fafc339dd714dfa  ./dawn$pkg$compiler_plan.exitmem.core
 d8ef31b3b287fe750d93c1c9862172f62af82d7dc1b84a6fd82a70ec3a53600d  ./dawn$pkg$compiler_plan.manifestv.core
 0699a9028c3f19a3ca61dc8e676a3bbc3afd067e4cfc3158cad3efa3941a7e64  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core
@@ -54,7 +54,7 @@ ea161d1de7c93f569e4cd223c16e5d22aa22161e6f3784f4c721aae789f9cc48  ./front.token.
 8e023a703177a61d6d50b42e9420048741690f2b748f7f02f4765e6f7d4b3d22  ./ir.lower.core
 4fdb14327a6a1032b4e6cc16dffdc234fc94451afa38fe9b0a6faaefade9ba00  ./ir.reach.core
 aca1eb870fba25749b6cdb58d4025bdf5e94abd92f943325176501c2f57dd877  ./jvm.codegen.core
-80a20323704ef1fe2fa6310d3c6f3afba9333a0b54ee88ea5b7c7ed4d8361b62  ./jvm.emit.core
+462a6aebc28a2d7315d38d45b0c9bead9fb8d491a2b94bf251023155289e565f  ./jvm.emit.core
 0a1b8c0017e1d68259ebbfe6a74daf7c2d48e2f0cac46d315f38616be9df69c0  ./jvm.help.core
 b936d8bb7d51afe453d3bbfb529f9824f73946c427e088dea09817135ce97cbb  ./jvm.jarw.core
 70338f60c462b694a9514f1f6ab90c8b4721e2406b86c008554bc7c3999a7540  ./jvm.jfold.core
@@ -64,7 +64,7 @@ c1da51783bb4bc867d5ba841f62574789fdb69bcefd5bd962cae61ae4d2c01a9  ./jvm.ops.core
 45a3fe7637b9ec370ba4846fdd05e44d4cbce69fb29c42c964f21304e3c4d203  ./jvm.rtclasses.core
 2103a2252c3781229ed03c8ac7ad1098a1afae2f440077db2c7f10e3585ec485  ./jvm.testrun.core
 e158469c2fdadd52d85f2505d424359cd521db8932476803dc55f75db6947340  ./lsp.lspc.core
-9df59b4f6349dcc6c73caeed0c0e75e4099ffe97ad38d6e1b3c0aad2d4da87a8  ./lsp.lspq.core
+6c7b2a5d64df21368803e8d18af92640ce115fc9ef98ff2a5be137fb093627d8  ./lsp.lspq.core
 03832c86df038739df922fd51376adbf8539c1fbd843f57f99942744c15ef88b  ./lsp.server.core
 f68ebf7f3959e39045134e24709fa5a1713a201eddb0626b2f8a6469ebdf720d  ./main.core
 d55989d03e7e43c8ac54bff952fea230e06182d5701e364c65e6b453e424c172  ./nmain.core

--- a/scripts/spike-native/matrix.txt
+++ b/scripts/spike-native/matrix.txt
@@ -110,6 +110,7 @@ long_string
 loop_operand
 named_args
 narrow_round
+never_statements
 nonfinite_const
 opaque
 operand_snapshot

--- a/scripts/spike-native/never_statements.dawn
+++ b/scripts/spike-native/never_statements.dawn
@@ -58,7 +58,8 @@ fn condition() -> Int = {
   z
 }
 
-fn returned() -> Int = {
+fn returned(take: Bool) -> Int = {
+  if not take { return 7 }
   let y: List[Int] = [{ return 7 }]
   len(y)
 }
@@ -108,7 +109,7 @@ pub fn main() -> Unit !io = {
   println(caught(() => statement_if(true)))
   println(caught(() => statement_if(false)))
   println(caught(condition))
-  println(to_string(returned()))
+  println(to_string(returned(take_lists)))
   println(to_string(live(false)))
   println(to_string(loops()))
 }

--- a/scripts/spike-native/never_statements.dawn
+++ b/scripts/spike-native/never_statements.dawn
@@ -1,0 +1,114 @@
+# Statement fallthrough must reach the block, including its tail (#93).
+# Reading the initialized local afterwards distinguishes this from emitting
+# dead but valid bytecode. Live branches and loop steps are negative controls.
+fn stop() -> Never = panic("stop")
+
+fn direct() -> Int = {
+  let y: Int = stop()
+  y
+}
+
+fn first(take: Bool) -> Int = {
+  if not take { return 21 }
+  let y: List[Int] = [stop()]
+  len(y)
+}
+
+fn second(take: Bool) -> Int = {
+  if not take { return 22 }
+  let y: List[Int] = [1, stop()]
+  len(y)
+}
+
+fn branches(take: Bool) -> Int = {
+  let y: Int = if take { stop() } else { stop() }
+  y
+}
+
+fn nested() -> Int = {
+  let y: Int = {
+    let z: Int = stop()
+    z
+  }
+  y
+}
+
+fn assigned() -> Int = {
+  var y = 0
+  y = stop()
+  let z: Int = stop()
+  z + y
+}
+
+fn discarded() -> Int = {
+  stop()
+  let z: Int = stop()
+  z
+}
+
+fn statement_if(take: Bool) -> Int = {
+  if take { stop() } else { stop() }
+  let z: Int = stop()
+  z
+}
+
+fn condition() -> Int = {
+  if stop() { () } else { () }
+  let z: Int = stop()
+  z
+}
+
+fn returned() -> Int = {
+  let y: List[Int] = [{ return 7 }]
+  len(y)
+}
+
+fn live(take: Bool) -> Int = {
+  let y: Int = if take { stop() } else { 9 }
+  y + 1
+}
+
+fn loops() -> Int = {
+  var total = 0
+  for i in 0..4 {
+    if i == 1 { continue }
+    total = total + i
+  }
+  while true {
+    let x: Int = { break }
+    total = total + x
+  }
+  var n = 0
+  while n < 3 {
+    n = n + 1
+    let x: Int = { continue }
+    total = total + x
+  }
+  total + n
+}
+
+fn caught(f: fn() -> Int) -> String !io =
+  match catch_panic(f) {
+    Err(e) -> e.message
+    Ok(v) -> to_string(v)
+  }
+
+pub fn main() -> Unit !io = {
+  # Both list branches must compile even when skipped. The JVM contract also
+  # runs them taken; native's taken paths leak until the separate #94 fix.
+  let take_lists = len(args()) > 0
+  println(caught(direct))
+  println(caught(() => first(take_lists)))
+  println(caught(() => second(take_lists)))
+  println(caught(() => branches(true)))
+  println(caught(() => branches(false)))
+  println(caught(nested))
+  println(caught(assigned))
+  println(caught(discarded))
+  println(caught(() => statement_if(true)))
+  println(caught(() => statement_if(false)))
+  println(caught(condition))
+  println(to_string(returned()))
+  println(to_string(live(false)))
+  println(to_string(loops()))
+}

--- a/scripts/spike-native/never_statements.expect
+++ b/scripts/spike-native/never_statements.expect
@@ -1,0 +1,14 @@
+stop
+21
+22
+stop
+stop
+stop
+stop
+stop
+stop
+stop
+stop
+7
+10
+8

--- a/selfhost/src/jvm/emit.dawn
+++ b/selfhost/src/jvm/emit.dawn
@@ -2375,7 +2375,8 @@ fn gen_cif(
 ) -> (Gen, Bool) !io = {
   let else_l = Label.new()
   let end = Label.new()
-  let (g1, _) = gen_cexpr(gx, g, cond, false)
+  let (g1, cond_falls) = gen_cexpr(gx, g, cond, false)
+  if not cond_falls { return (g1, false) }
   g1.mv.visitJumpInsn(OP_IFEQ, else_l)
   let (g2, then_falls) = gen_cexpr(gx, g1, thn, tail)
   if discard && then_falls { pop_value(g2.mv, cex_ty(thn)) }
@@ -2449,7 +2450,9 @@ pub fn gen_cexpr(gx: GenCtx, g: Gen, e: CExpr, tail: Bool) -> (Gen, Bool) !io =
     CBlock(stmts, tl, ty) -> {
       var g1 = g
       for s in stmts {
-        g1 = gen_cstmt(gx, g1, s)
+        let (g2, stmt_falls) = gen_cstmt(gx, g1, s)
+        g1 = g2
+        if not stmt_falls { return (g1, false) }
       }
       match tl {
         Some(t) -> gen_cexpr(gx, g1, t, tail)
@@ -2811,33 +2814,33 @@ fn gen_cbinary(gx: GenCtx, g: Gen, op: CBinOp, l: CExpr, r: CExpr, ty: Ty) -> (G
   (g1, true)
 }
 
-fn gen_cstmt(gx: GenCtx, g: Gen, s: CStmt) -> Gen !io =
+## A statement owes the enclosing block its fallthrough, too. In particular
+## a non-returning initializer binds no local slot: emitting the next read
+## anyway is a compiler panic, not harmless unreachable bytecode (#93).
+fn gen_cstmt(gx: GenCtx, g: Gen, s: CStmt) -> (Gen, Bool) !io =
   match s {
     CSLet(sym, ty, init) -> {
       let (g1, falls) = gen_cexpr(gx, g, init, false)
-      if not falls { return g1 }
+      if not falls { return (g1, false) }
       let (g2, slot) = alloc(g1, slots_of(ty))
       store_slot(g2.mv, ty, slot)
-      cbind(g2, sym, ty, slot)
+      (cbind(g2, sym, ty, slot), true)
     }
     CSAssign(sym, value) -> {
       let (g1, falls) = gen_cexpr(gx, g, value, false)
       if falls { store_var(g1, sym) }
-      g1
+      (g1, falls)
     }
     # the node that exists because a dropped value is not a dropped effect
     CSDiscard(e) -> {
       let (g1, falls) = gen_cexpr(gx, g, e, false)
       if falls { pop_value(g1.mv, cex_ty(e)) }
-      g1
+      (g1, falls)
     }
     # `discard` rather than a pop afterwards: each branch drops its own value,
     # so both reach the merge with the same empty stack and the else-less
     # case owes nothing.
-    CSIf(cond, thn, els) -> {
-      let (g1, _) = gen_cif(gx, g, cond, thn, els, TyUnit, false, true)
-      g1
-    }
+    CSIf(cond, thn, els) -> gen_cif(gx, g, cond, thn, els, TyUnit, false, true)
     CSLoop(id, body, step) -> {
       let top = Label.new()
       let cont = Label.new()
@@ -2862,10 +2865,12 @@ fn gen_cstmt(gx: GenCtx, g: Gen, s: CStmt) -> Gen !io =
       }
       g1.mv.visitJumpInsn(OP_GOTO, top)
       g1.mv.visitLabel(brk)
-      Gen { ..g1, cloops: list.take(g1.cloops, len(g1.cloops) - 1) }
+      # A non-falling body can reach either loop label via break/continue.
+      # Keep the step and conservatively allow the path after the break label.
+      (Gen { ..g1, cloops: list.take(g1.cloops, len(g1.cloops) - 1) }, true)
     }
     # reference counting: Perceus emits these, the JVM has a collector
-    CSDrop(_) -> g
+    CSDrop(_) -> (g, true)
   }
 
 ## The list primitives, implemented by calling the Dawn vector in std/pvec.


### PR DESCRIPTION
## Summary

Closes #93.

Propagate fallthrough from JVM statement emission to its enclosing block. A non-returning initializer must not bind a slot, and the block must not emit later reads of that slot. Assignment, discard and conditional statements propagate the same result; a non-returning if condition stops before either branch. Loops conservatively retain their break/continue/step paths.

## Verification

- 613 selfhost tests passed.
- 14 compiling Never mutants passed their owning assertions, including the new statement-flow mutant.
- Added executable classfile verification and JVM/native corpus with handwritten outputs, covering direct/list/nested initializers, terminating branches, assignment/discard, return and reachable loop/branch controls.
- Previous-release differential passed with no new Emit-Change declarations.
- Inspected and re-recorded compiler Core hashes; full Core text corpus unchanged.
- Bootstrap fixed point and documentation check also run locally; full required CI is required before merge.

The new ASan coverage exposed separate native leak #94. This PR's native corpus runs the unselected list branch (which still reproduces #93 during JVM compilation); the JVM classfile probe additionally runs the taken list paths. No ASan disable or known-red exemption was added. The native taken-path leak is next in the queue.
