### PR TITLE
Reconcile SEM-10 status with its fixed implementation

### DIFF
--- a/docs/codebase-audit-v2.md
+++ b/docs/codebase-audit-v2.md
@@ -103,10 +103,10 @@ corpus；#193 见 `16f508c`、`0a3a4ba`、`3c9472c` 及 `scripts/spike-native/ru
 | **open** | 发现仍成立；其中可包含 HOLD、延后能力或待 ABI/产品裁决项，执行状态另行注明。 |
 | **retracted** | 逐项复核后认定原发现把已明确、内部一致的设计选择误当成缺陷；不是“通过实现修好”。 |
 
-#### 当前 fixed（85）
+#### 当前 fixed（86）
 
 - 语法（18）：`SYN-01`–`SYN-16`、`SYN-18`、`SYN-19`。
-- 语义（13）：`SEM-01`–`SEM-03`、`SEM-06`、`SEM-07`、`SEM-11`–`SEM-18`。
+- 语义（14）：`SEM-01`–`SEM-03`、`SEM-06`、`SEM-07`、`SEM-10`–`SEM-18`。
 - 架构（6）：`ARC-03`–`ARC-06`、`ARC-12`、`ARC-13`。
 - 工具链（17）：`TOOL-01`–`TOOL-17`。
 - 库（18）：`LIB-01`–`LIB-15`、`LIB-17`–`LIB-19`。
@@ -118,18 +118,18 @@ corpus；#193 见 `16f508c`、`0a3a4ba`、`3c9472c` 及 `scripts/spike-native/ru
 - 架构（4）：`ARC-01`、`ARC-02`、`ARC-08`、`ARC-11`。
 - 库（1）：`LIB-16`。
 
-#### 当前 open（6）
+#### 当前 open（5）
 
 - 语法（1）：`SYN-17`。
-- 语义（2）：`SEM-09`、`SEM-10`。
+- 语义（1）：`SEM-09`。
 - 架构（3）：`ARC-07`、`ARC-09`、`ARC-10`。
 
 #### 当前 retracted（2）
 
 - 语义（2）：`SEM-05`、`SEM-08`。
 
-当前计数自检：**85 fixed + 6 partial + 6 open + 2 retracted = 99**。逐专题矩阵：
-语法 **18/0/1/0**、语义 **13/1/2/2**、架构 **6/4/3/0**、工具链 **17/0/0/0**、
+当前计数自检：**86 fixed + 6 partial + 5 open + 2 retracted = 99**。逐专题矩阵：
+语法 **18/0/1/0**、语义 **14/1/1/2**、架构 **6/4/3/0**、工具链 **17/0/0/0**、
 库 **18/1/0/0**、治理 **13/0/0/0**（顺序均为 fixed/partial/open/retracted）。
 状态迁移逐项为：`LIB-07` fixed、`ARC-11` partial、`SEM-06` fixed、`TOOL-08` fixed、
 `TOOL-14` fixed → partial（订正冒称的 fixed，后由 `3e13645` 的 v2 generation 收口回

--- a/docs/codebase-audit-v2/02-types-effects-and-semantics.md
+++ b/docs/codebase-audit-v2/02-types-effects-and-semantics.md
@@ -265,7 +265,13 @@
 
 ## SEM-10 — P2 — trait/impl 与具名 effect 不能组合（已修）
 
-<!-- audit-anchor: absent selfhost/src/check/passes.dawn | trait methods cannot declare the effect -->
+<!-- audit-anchor: present selfhost/src/check/passes.dawn | trait methods cannot declare the effect -->
+
+> **台账订正（2026-09-07）：** 总纲漏迁移为 fixed，且删除旧拒绝诊断的 anchor 被反写成
+> absent，两错抵消使门禁保持绿。恢复「缺陷存在时诊断 present」的固定方向并同步总纲。
+> 门禁补充：条目标题明确写「已修」时，当前状态必须是 fixed；只读标题，不把下文历史
+> open 记录当作当前状态。负控重放两错同时恢复，必须单独命中标题/状态一致性断言；
+> 单改 anchor 和恢复源码诊断仍各自由原有树证据断言负责。不改变历史冻结层。
 
 > **后续处置（2026-08-20，RX-10-B 刀 5）：已修，关账。** 本条要的 ABI 裁决在
 > [`effect-params-design.md`](../effect-params-design.md) 决策 5（规则丙）作出并随刀 5 落地：

--- a/scripts/doc-check.py
+++ b/scripts/doc-check.py
@@ -3229,6 +3229,12 @@ def audit_anchor_problems(detail_texts: dict[str, str],
         status = owner.get(audit_id)
         if status is None:
             continue
+        # An explicit current heading is not the historical prose below it.
+        # SEM-10's stale open state and inverted anchor used to cancel out.
+        if "（已修）" in entries[audit_id].splitlines()[0] and status != "fixed":
+            bad.append(f"{audit_id}: heading says fixed, registry says {status} "
+                       "[heading_matches_status]")
+            continue
         anchors = AUDIT_ANCHOR.findall(entries[audit_id])
         if len(anchors) > 1:
             bad.append(f"{audit_id}: carries {len(anchors)} audit-anchors; one "
@@ -3330,6 +3336,9 @@ def check_audit_anchors() -> tuple[list[str], int]:
 # reads one named file rather than the repository, so writing the code out in
 # the audit document does not answer the question the anchor asks.
 AUDIT_ANCHOR_MUTANTS = (
+    ("restore-sem10-stale-state-and-inverted-anchor", "heading_matches_status"),
+    ("invert-sem10-anchor", "fixed_took_effect"),
+    ("restore-sem10-rejection", "fixed_took_effect"),
     ("an-open-finding-whose-code-was-fixed", "open_still_true"),
     ("a-fixed-finding-whose-fix-is-gone", "fixed_took_effect"),
     ("an-open-finding-with-no-anchor", "anchor_required"),
@@ -3352,7 +3361,19 @@ def audit_anchor_mutant(name: str, details: dict[str, str],
     rel = "docs/codebase-audit-v2/02-types-effects-and-semantics.md"
     probe = "\n## SEM-99 — P2 — self-test probe\n\n" \
             "<!-- audit-anchor: absent std/cursor.dawn | dawn_selftest_probe -->\n"
-    if name == "an-open-finding-whose-code-was-fixed":
+    if name == "restore-sem10-stale-state-and-inverted-anchor":
+        states["fixed"].remove("SEM-10")
+        states["open"].add("SEM-10")
+        details[rel] = details[rel].replace(
+            "audit-anchor: present selfhost/src/check/passes.dawn | trait methods cannot declare the effect",
+            "audit-anchor: absent selfhost/src/check/passes.dawn | trait methods cannot declare the effect")
+    elif name == "invert-sem10-anchor":
+        details[rel] = details[rel].replace(
+            "audit-anchor: present selfhost/src/check/passes.dawn | trait methods cannot declare the effect",
+            "audit-anchor: absent selfhost/src/check/passes.dawn | trait methods cannot declare the effect")
+    elif name == "restore-sem10-rejection":
+        sources["selfhost/src/check/passes.dawn"] += "\ntrait methods cannot declare the effect\n"
+    elif name == "an-open-finding-whose-code-was-fixed":
         details[rel] += probe
         states["open"].add("SEM-99")
         sources["std/cursor.dawn"] += "\nfn dawn_selftest_probe() = 1\n"


### PR DESCRIPTION
Closes #100.

Restore SEM-10 to fixed and its source anchor to present. Update only current counts (86 fixed / 6 partial / 5 open / 2 retracted), preserving the frozen historical partition. Explicit fixed detail headings now contradict non-fixed registry entries even when an inverted source anchor would cancel the error.

Three independent negative controls replay paired stale state/inverted anchor, anchor-only inversion, and restored source rejection. Full doc-check passed: 132 negative controls; targeted audit status, anchors, current and historical partition checks also passed.

No compiler output, release or deployment changes.