### PR TITLE
Extract cold module transitions with an independent semantic oracle

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1038,6 +1038,26 @@ jobs:
     # observation supersedes the 491s planning value; 3x is 1674s, so the
     # timeout is 28 minutes. It remains below the 660s run-pole, which does
     # not move.
+  incremental-semantics:
+    runs-on: ubuntu-latest
+    # Planning value until the first CI observation: the complete probe,
+    # frozen-loop mutants and inline suite took 81.07s locally on 2026-09-08.
+    # Double the rounded 82s for runner variance, plus 38s toolchain/checkout
+    # overhead observed for contracts-1: 202s. Keep this separate as the
+    # incremental contract grows rather than consuming contracts-1's budget.
+    # budget: 3x 202s planning value
+    timeout-minutes: 11
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/dawn-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: incremental semantic observation and cold reference
+        run: |
+          python3 scripts/incremental-semantics-contract/probe.py
+          python3 scripts/incremental-semantics-contract/cold.py
+          ./bin/dawn test scripts/incremental-semantics-contract
+
   contracts-1:
     runs-on: ubuntu-latest
     # No CI observation of this half exists yet -- the job is new. The
@@ -1068,11 +1088,6 @@ jobs:
       # partition the script's no-flag run.
       - name: classfile verification
         run: ./scripts/classfile-verify/run.sh --without-never-mutants
-
-      - name: incremental semantic query observation
-        run: |
-          python3 scripts/incremental-semantics-contract/probe.py
-          ./bin/dawn test scripts/incremental-semantics-contract
 
       # K-A7: the compiler emits `dawn/rt/Asm`, the five null adapters that
       # used to be the last handwritten Java in the trusted base. Every other

--- a/docs/incremental-semantics-design.md
+++ b/docs/incremental-semantics-design.md
@@ -10,8 +10,11 @@ debounce 和一致 Program；缺的是跨编辑的语义复用。`driver/analyze
 逐模块推进 exports、全局 impls 和 next_id，因此文本不变并不意味着模块结果可复用。
 Playground 使用非 file URI，属于 standalone；模块前缀复用不能加速每次都变的单模块。
 
-尚未运行本项目基准。必须测 load/parse/check/comptime/query 各阶段、真实编辑的首差
-位置和保留内存，再决定启用范围；不写未经实测的加速倍数。
+已运行 hello_mod/selfhost 的探索性冷路径基准；可复现入口是
+`scripts/incremental-semantics-contract/bench.py`，原始轮次、源码指纹、环境和进程 RSS
+分别归档，cold/observed 交替顺序。parse replay 不冒充 loader 内部分段，进程 RSS
+不冒充缓存保留内存。仍需真实编辑首差、query 延迟及保留内存测量，再决定启用范围；
+不写未经实测的加速倍数。
 
 ## 二、首个交付：保守模块前缀
 
@@ -72,7 +75,14 @@ Java可变对象。共享模块两个测试守八个hook的观察顺序与refusi
 计数独立、零查询gate、返回值与参数方向；项目夹具证明经import的Java对象仍触发查询。
 `scripts/incremental-semantics-contract/probe.py` 先核验全部锚点，然后实际编译九个
 变异体，每个必须命中owning测试，构建错误不算证据；workflow已接线。第一期仍缺
-冷路径分阶段观测、对照语料和性能基线，不能据此宣称第一期完成。
+真实编辑/query/保留内存基线，不能据此宣称第一期完成。
+
+第二刀抽取 `AnalysisCarry/ModuleStep`，`analyze_program` 仍走无 observer 的
+cold fold；阶段事件只由显式 `analyze_observed` 请求。私有夹具注入冻结的旧循环，
+以相同捕获输入对照完整 Program/Cx，不只比较公开签名。独立 javac 比较器避开测试
+程序的泛型 Eq 字典构造器问题，不改变生产发射。六个成功编译的变异体覆盖输入 ID、
+impl carry、诊断顺序、check/comptime 跳过和 std baseline；编译/反射错误不算负控。
+原始实现与独立循环的13组结果对拍、六个负控及350项夹具测试已在本地通过。
 
 首刀本地618个selfhost测试、集成套件214个测试、九个可编译负控和完整文档门通过。
 native侧484个selfhost测试通过，自举B==C固定点和独立calc发射冒烟通过；重录后Core门通过。

--- a/scripts/core-golden/selfhost.norm.sha
+++ b/scripts/core-golden/selfhost.norm.sha
@@ -13,7 +13,7 @@ f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.c
 32847738a975b9c9715fb1804dcac0008e3f60299d96977a516bd92ff72a4a6a  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-f69b1f074c4b4b8bb4e10ab2b336fc4449bdb9f8fdcda3f2a61b3a9a8905e013  ./dawn$pkg$compiler_plan.exitmem.core
+befaa5d9f392d37e8f717938e19af65783366dddeed68d40d1c3c361ec33eb78  ./dawn$pkg$compiler_plan.exitmem.core
 5e90809d7cf26b47edd232da9ed4d54e185dbaa36a4ee4b718a8c58bf6ee1c33  ./dawn$pkg$compiler_plan.manifestv.core
 f998cbf9d2c3c3712ac981592cf658f61944f43196b81f992b3d583794561297  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core
@@ -30,7 +30,7 @@ f2d4777dbd277027c7d85f912bae29caf8d92c219d41dba13a38a9f3f55f4271  ./dawn$pkg$jso
 13bc498b5e704011c1f5843c5da527cd91a2d9166f0678f25ad2bfca6940f99d  ./dawn$pkg$json2.value.core
 4019ad394b2e2bd06aec5e8e6590be4e369c715fd54f57314df9036b5f0bff07  ./dawn$pkg$sha2.sha256.core
 de72b0a760ab9d0fabf6a8efcee97555e23baef075eab4f04571f35391192114  ./doc.core
-522eaf71fe0ed92bf4407fbce46ac36b3160d692471d32062c95a3a34d024dd5  ./driver.analyze.core
+c1418f11f19a6c34bdfadf7af36a38f56a67c97416d62e91b48f97a988ca1496  ./driver.analyze.core
 eeb8923f514acdf745419c3715a18b1ffa3b32919d92441996dfac199d7795d8  ./driver.checkdump.core
 0682165d07836cba6379f89941893f40c88c6f3df88c5c8571a328b1b812e2f3  ./driver.fsmem.core
 db1aa05296625cf27b1e8dd21494bbc33e78e04c654ca8fa73676bc059b430e7  ./driver.stdlib.core

--- a/scripts/core-golden/selfhost.sha
+++ b/scripts/core-golden/selfhost.sha
@@ -10,10 +10,10 @@ d55782f8e992c365f3feee140c163b7aaf4fc1e879746821d934a94aefdd68c7  ./c.rc.core
 ed2443ce9bf5757fae1b17937e79a1a1fddac93880b0a778c27b6eadb35d02f2  ./check.passes.core
 f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.core
 fb2393f9577ee9acb66a53802e0acf05cabf9f2b5e856c48e47573a1b342fd9c  ./check.types.core
-7191d34d351303ab89047fb23d08c7ca081c2e497655ac21ab49c3b201cd4138  ./dawn$pkg$compiler_plan.consolemem.core
+c7ebef95f88d6b6be7c1d66c122123861d3713cd157412007ab7606dcda3a849  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-f69b1f074c4b4b8bb4e10ab2b336fc4449bdb9f8fdcda3f2a61b3a9a8905e013  ./dawn$pkg$compiler_plan.exitmem.core
+befaa5d9f392d37e8f717938e19af65783366dddeed68d40d1c3c361ec33eb78  ./dawn$pkg$compiler_plan.exitmem.core
 da4bcb58e63f8fce15fa28b5f49a2e9d366f77b3cbbb0264e79f86039f6ed537  ./dawn$pkg$compiler_plan.manifestv.core
 f998cbf9d2c3c3712ac981592cf658f61944f43196b81f992b3d583794561297  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core
@@ -30,7 +30,7 @@ f2d4777dbd277027c7d85f912bae29caf8d92c219d41dba13a38a9f3f55f4271  ./dawn$pkg$jso
 13bc498b5e704011c1f5843c5da527cd91a2d9166f0678f25ad2bfca6940f99d  ./dawn$pkg$json2.value.core
 4019ad394b2e2bd06aec5e8e6590be4e369c715fd54f57314df9036b5f0bff07  ./dawn$pkg$sha2.sha256.core
 de72b0a760ab9d0fabf6a8efcee97555e23baef075eab4f04571f35391192114  ./doc.core
-da1a977c7f33512516af1fdefb6a38dc99cc26a719ce89d151d7159a2f5ac660  ./driver.analyze.core
+b9879dd76389481e4a5a1d2c1db2bdf36abeaf752350b93819c9aa78cb9fa47a  ./driver.analyze.core
 eeb8923f514acdf745419c3715a18b1ffa3b32919d92441996dfac199d7795d8  ./driver.checkdump.core
 0682165d07836cba6379f89941893f40c88c6f3df88c5c8571a328b1b812e2f3  ./driver.fsmem.core
 adda09359afeed9b853ca61b5cb54bf97b05d8af1bc4862da3cd88fcbed72d7a  ./driver.stdlib.core
@@ -64,7 +64,7 @@ c1da51783bb4bc867d5ba841f62574789fdb69bcefd5bd962cae61ae4d2c01a9  ./jvm.ops.core
 a453487ebbff8a1e04de17df359671b385074ea4a41beff0695a3a5d727ec2da  ./jvm.rtclasses.core
 2103a2252c3781229ed03c8ac7ad1098a1afae2f440077db2c7f10e3585ec485  ./jvm.testrun.core
 e158469c2fdadd52d85f2505d424359cd521db8932476803dc55f75db6947340  ./lsp.lspc.core
-b4e1df47c71353f52ce2e5b19749bed68d83db65634b943d17fe09e95f8910fe  ./lsp.lspq.core
+2fed4ff43a3049dc68c54f86ea32a09479a910c6a4e09ce2fe501d1b672d4a76  ./lsp.lspq.core
 7a74a0bd319e3db2f00e0166e7beae3225da10cd81d5bdb6876b140baf03358b  ./lsp.server.core
 446c4ef95202014677e3ccfc58ccd6a73aa2db9b69e37abcdd40edc76854abea  ./main.core
 9669e751c94dae608ccbc455d381f82625fe07ff6be095175e78b6a1a1b83aee  ./nmain.core

--- a/scripts/incremental-semantics-contract/README.md
+++ b/scripts/incremental-semantics-contract/README.md
@@ -1,0 +1,41 @@
+# 增量语义契约夹具
+
+生产入口仍是冷分析；这些命令不证明已经实现缓存。
+
+- `python3 scripts/incremental-semantics-contract/probe.py`：八个 Java hook 与
+  refusing guard 的九个可编译负控。
+- `./bin/dawn test scripts/incremental-semantics-contract`：query probe 集成、
+  冷路径阶段嵌套、错误恢复和 loader 诊断顺序。
+- `python3 scripts/incremental-semantics-contract/cold.py`：私有源码副本中注入
+  冻结旧循环，对照相同 StdCtx、LoadedModule 和 CtOpts；六个变异体只改新路径。
+  需 JDK 21+ 的 `java/javac/jar`。
+
+旧循环来自 `58ebd4a5` 的 `analyze_program`，仅改函数名；它共享未改动的
+checker/stdlib helpers，不调用新 transition。13 组结果覆盖模块换序、恢复诊断、
+parse/check/comptime 失败、impl/ID 传递和 std 的 impls_before 特例。
+
+比较器由 javac 独立编译，通过反射比较整个 Program（包括 AST/TAST、comptime、
+完整 Cx）。只排除 Cx 中同一 refusing oracle 的 jsig 能力；Array 比较逻辑长度内
+的内容，不比较 backing capacity/append watermark。未知宿主对象抛错，不算相等。
+新增字段自动参与比较，循环引用用对象对去重；浮点按原始位比较。Java 的标量、嵌套数组、
+循环引用和未知对象有自检。采用独立比较器是因为直接生成完整 Cx 的 Eq 字典时，
+测试程序出现 List_Int 构造器描述符不匹配；此处未修改编译器发射契约。
+
+负控必须成功构建且命中明确的语义差异断言；编译错误、反射错误、timeout 不算通过。
+impl 负控清掉 checker 的输入 impl carry，而不是清掉输出 fold 的初值：后者会被
+完整 cx.impl_table 重新补齐，是等价变异体，不能用来证明门禁失效。
+
+## 冷路径基准
+
+```sh
+python3 scripts/incremental-semantics-contract/bench.py \
+  --java-home /path/to/jdk21 \
+  --output review/cold-baseline-new \
+  examples/projects/hello_mod selfhost
+```
+
+输出目录必须不存在。每个目标使用独立 JVM，同一 captured plan/target Java lease
+中跑11轮，丢前3轮，cold/observed 交替先后顺序。保存逐轮 TSV、源码 SHA-256、
+JDK/OS/参数、构建日志、摘要和进程峰值 RSS；每轮必须无诊断且所有模块执行 check/comptime。
+parse replay 不是 loader 内部分段，不能从 load 相减；RSS 包含启动、std 和整个进程，
+不是缓存保留内存。八个样本不足以声称稳定的加速倍数，也没有测量尚未实现的 warm 路径。

--- a/scripts/incremental-semantics-contract/SemanticSnapshot.java
+++ b/scripts/incremental-semantics-contract/SemanticSnapshot.java
@@ -1,0 +1,128 @@
+package contract;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.IdentityHashMap;
+
+/**
+ * Independent test oracle: do not rely on the compiler's generated Eq dictionaries.
+ * Dawn Array backing capacity and the append watermark are not logical contents.
+ * Everything else is compared field-for-field; unknown host capabilities fail closed.
+ */
+public final class SemanticSnapshot {
+    public static void main(String[] args) throws Exception {
+        selfTest();
+        String owner = "cold transition agrees with the frozen loop on full semantic products";
+        Class<?> reference = Class.forName("reference");
+        Object samples = reference.getMethod("samples").invoke(null);
+        var count = java.util.Arrays.stream(reference.getMethods())
+                .filter(m -> m.getName().equals("sample_count")).findFirst().orElseThrow();
+        var at = java.util.Arrays.stream(reference.getMethods())
+                .filter(m -> m.getName().equals("sample_at")).findFirst().orElseThrow();
+        long length = (Long) count.invoke(null, samples);
+        if (length != 13) throw new AssertionError("Expected 13 full-product pairs, got " + length);
+        for (int i = 0; i < length; i++) {
+            Object pair = at.invoke(null, samples, (long) i);
+            Object a = pair.getClass().getField("old").get(pair);
+            Object b = pair.getClass().getField("current").get(pair);
+            if (!same(a, b)) {
+                System.out.println("FAIL  reference :: " + owner + " (case " + i + ")");
+                System.exit(1);
+            }
+        }
+        System.out.println("PASS  reference :: " + owner);
+    }
+
+    private static void selfTest() throws ReflectiveOperationException {
+        if (!same(new Object[]{new long[]{1, 2}, "x", null},
+                  new Object[]{new long[]{1, 2}, "x", null})
+                || same(new Object[]{new long[]{1, 2}}, new Object[]{new long[]{1, 3}})
+                || same(new long[]{1}, new long[]{1, 2})
+                || same(null, "x") || same(0.0, -0.0)
+                || same(Double.longBitsToDouble(0x7ff8000000000001L),
+                        Double.longBitsToDouble(0x7ff8000000000002L))) {
+            throw new AssertionError("Structural comparator control failed");
+        }
+        Object[] a = new Object[2];
+        Object[] b = new Object[2];
+        a[0] = a;
+        b[0] = b;
+        a[1] = 1L;
+        b[1] = 1L;
+        if (!same(a, b)) throw new AssertionError("Cycle equality control failed");
+        b[1] = 2L;
+        if (same(a, b)) throw new AssertionError("Cycle inequality control failed");
+        try {
+            same(new Object(), new Object());
+            throw new AssertionError("Unknown host object was accepted");
+        } catch (IllegalArgumentException expected) {
+            // Unknown capabilities cannot silently compare equal.
+        }
+    }
+
+    public static boolean same(Object a, Object b) throws ReflectiveOperationException {
+        return same(a, b, new IdentityHashMap<>());
+    }
+
+    private static boolean same(Object a, Object b,
+            IdentityHashMap<Object, IdentityHashMap<Object, Boolean>> seen)
+            throws ReflectiveOperationException {
+        if (a == null || b == null) return a == b;
+        Class<?> type = a.getClass();
+        if (type != b.getClass()) return false;
+        if (a instanceof String || a instanceof Long || a instanceof Integer
+                || a instanceof Boolean || a instanceof Byte || a instanceof Short
+                || a instanceof Character) return a.equals(b);
+        if (a instanceof Double x) {
+            return Double.doubleToRawLongBits(x) == Double.doubleToRawLongBits((Double) b);
+        }
+        if (a instanceof Float x) {
+            return Float.floatToRawIntBits(x) == Float.floatToRawIntBits((Float) b);
+        }
+        if (!type.isArray() && (!(type.getName().startsWith("dawn.")
+                || type.getName().startsWith("dawn$")
+                || type.getName().startsWith("std.")
+                || type.getName().startsWith("Option$")
+                || type.getName().startsWith("Result$"))
+                || type.isSynthetic())) {
+            throw new IllegalArgumentException("Unsupported semantic product: " + type.getName());
+        }
+        var partners = seen.computeIfAbsent(a, ignored -> new IdentityHashMap<>());
+        if (partners.put(b, Boolean.TRUE) != null) return true;
+        if (type.getName().equals("dawn.rt.Array")) {
+            Field length = type.getDeclaredField("len");
+            Field contents = type.getDeclaredField("a");
+            length.setAccessible(true);
+            contents.setAccessible(true);
+            int n = length.getInt(a);
+            if (n != length.getInt(b)) return false;
+            Object[] left = (Object[]) contents.get(a);
+            Object[] right = (Object[]) contents.get(b);
+            for (int i = 0; i < n; i++) {
+                if (!same(left[i], right[i], seen)) return false;
+            }
+            return true;
+        }
+        if (type.isArray()) {
+            int n = java.lang.reflect.Array.getLength(a);
+            if (n != java.lang.reflect.Array.getLength(b)) return false;
+            for (int i = 0; i < n; i++) {
+                if (!same(java.lang.reflect.Array.get(a, i),
+                        java.lang.reflect.Array.get(b, i), seen)) return false;
+            }
+            return true;
+        }
+        for (Class<?> parent = type; parent != Object.class; parent = parent.getSuperclass()) {
+            for (Field field : parent.getDeclaredFields()) {
+                if (Modifier.isStatic(field.getModifiers())) continue;
+                // Cx carries an oracle capability, not semantic data. Both paths
+                // receive the same refusing oracle; every other field is compared.
+                if (field.getName().equals("jsig")
+                        && type.getName().endsWith("$Cx")) continue;
+                field.setAccessible(true);
+                if (!same(field.get(a), field.get(b), seen)) return false;
+            }
+        }
+        return true;
+    }
+}

--- a/scripts/incremental-semantics-contract/bench.py
+++ b/scripts/incremental-semantics-contract/bench.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Capture reproducible cold-stage samples, not an incremental speedup claim.
+
+Each target is a fresh JVM; paired analyses alternate order within that JVM.
+Parse replay is separate from loader timing. Peak RSS includes JVM startup,
+stdlib loading and all rounds, so it is not retained semantic-cache memory.
+"""
+import argparse
+import hashlib
+import json
+import platform
+from pathlib import Path
+import statistics
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+FIELDS = ["kind", "round", "target", "modules", "parsed_decls", "load_ns",
+          "parse_replay_ns", "observed_ns", "module_ns", "check_ns", "comptime_ns",
+          "cold_ns", "check_runs", "comptime_runs", "java_queries",
+          "observed_diags", "cold_diags", "order"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--java-home", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path,
+                        help="new directory; existing results are never overwritten")
+    parser.add_argument("targets", nargs="+")
+    args = parser.parse_args()
+    java = args.java_home.resolve() / "bin/java"
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    metadata = {
+        "head": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip(),
+        "platform": platform.platform(),
+        "java": subprocess.run([str(java), "-version"], text=True, capture_output=True,
+                               check=True).stderr,
+        "jvm_flags": ["-Xss512m", "-Xmx2g", "-XX:+UseSerialGC"],
+        "warmup_rounds": 3, "measured_rounds": 8,
+        "targets": args.targets,
+        "sources": {},
+        "limitations": ["parse replay is not an internal loader interval",
+                        "peak RSS is process-wide, not retained cache memory",
+                        "no warm incremental path exists in this benchmark yet"],
+    }
+    for directory in ("selfhost/src", "compiler-plan/src", "std",
+                      "scripts/incremental-semantics-contract"):
+        for path in sorted((ROOT / directory).rglob("*")):
+            if path.is_file() and path.suffix in (".dawn", ".toml", ".py", ".txt", ".java"):
+                metadata["sources"][str(path.relative_to(ROOT))] = hashlib.sha256(path.read_bytes()).hexdigest()
+    (output / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    with (output / "build.log").open("w") as log:
+        subprocess.run([str(ROOT / "bin/dawn"), "build", str(HERE), "-o", str(output / "bench.jar"),
+                        "--vendor", "org/objectweb/asm", "--vendor", "coursierapi"],
+                       cwd=ROOT, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=600)
+    summaries = []
+    for index, target in enumerate(args.targets):
+        command = ["/usr/bin/time", "-v", "-o", str(output / f"{index}.rss.txt"),
+                   str(java), *metadata["jvm_flags"], "-jar", str(output / "bench.jar"), target]
+        with (output / f"{index}.tsv").open("w") as stdout, (output / f"{index}.stderr").open("w") as stderr:
+            subprocess.run(command, cwd=ROOT, stdout=stdout, stderr=stderr, check=True, timeout=600)
+        rows = []
+        for line in (output / f"{index}.tsv").read_text().splitlines():
+            values = line.split("\t")
+            if values[0] == "meta":
+                continue
+            if len(values) != len(FIELDS) or values[0] != "round":
+                raise RuntimeError(f"invalid benchmark row: {line}")
+            row = dict(zip(FIELDS, values))
+            for field in FIELDS[3:17] + ["round"]:
+                row[field] = int(row[field])
+            if row["target"] != target or row["observed_diags"] or row["cold_diags"]:
+                raise RuntimeError(f"invalid analysis: {row}")
+            if row["check_runs"] != row["modules"] or row["comptime_runs"] != row["modules"]:
+                raise RuntimeError(f"incomplete stage coverage: {row}")
+            if row["order"] != ("observed-first" if row["round"] % 2 == 0 else "cold-first"):
+                raise RuntimeError(f"analysis order drift: {row}")
+            rows.append(row)
+        if [row["round"] for row in rows] != list(range(11)):
+            raise RuntimeError("expected exactly rounds 0..10")
+        measured = rows[3:]
+        summaries.append({
+            "target": target, "samples": 8,
+            "median_ms": {field: statistics.median(row[field] for row in measured) / 1e6
+                          for field in FIELDS if field.endswith("_ns")},
+            "raw": f"{index}.tsv", "process_peak_rss": f"{index}.rss.txt",
+        })
+    (output / "summary.json").write_text(json.dumps(summaries, indent=2) + "\n")
+    print(json.dumps(summaries, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/incremental-semantics-contract/cold.py
+++ b/scripts/incremental-semantics-contract/cold.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Check the extracted transition against the frozen pre-extraction loop.
+
+Both receive the same loaded inputs and StdCtx in a private subject. The
+reference shares unchanged low-level checker/stdlib helpers, but never calls
+ModuleStep or the observed fold. Each mutant changes only the new path.
+"""
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+HERE = Path(__file__).resolve().parent
+DAWN = os.environ.get("DAWN_BIN", str(ROOT / "bin/dawn"))
+OWNER = "cold transition agrees with the frozen loop on full semantic products"
+
+
+def run(*args):
+    result = subprocess.run([DAWN, *map(str, args)], cwd=ROOT, text=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=300)
+    return result.returncode, result.stdout
+
+
+def edit(text, old, new):
+    if text.count(old) != 1:
+        raise RuntimeError(f"cold mutation anchor drifted: {old!r}")
+    return text.replace(old, new)
+
+
+def main():
+    started = time.monotonic()
+    original = (ROOT / "selfhost/src/driver/analyze.dawn").read_text()
+    reference = (HERE / "reference-loop.dawn.txt").read_text()
+    variants = [
+        ("next-id", "    next_id: before.next_id,", "    next_id: std.next_id,"),
+        ("impl-carry", "  var base_impls = before.impls\n", "  var base_impls = std.impls\n"),
+        ("diagnostic-order", "    diags = diags ++ step.diags\n", "    diags = step.diags ++ diags\n"),
+        ("skip-check", "  if not parse_failed {\n", "  if false {\n"),
+        ("skip-comptime", "    if len(cx.diags) == 0 {\n", "    if false {\n"),
+        ("std-baseline", "      Some(before) -> { base_impls = before }", "      Some(before) -> ()"),
+    ]
+    subjects = [("positive", original)] + [(name, edit(original, old, new)) for name, old, new in variants]
+    with tempfile.TemporaryDirectory(prefix="dawn-cold-reference-") as temp:
+        root = Path(temp)
+        classes = root / "classes"
+        classes.mkdir()
+        subprocess.run(["javac", "--release", "21", "-d", str(classes),
+                        str(HERE / "SemanticSnapshot.java")], check=True)
+        oracle = root / "snapshot.jar"
+        subprocess.run(["jar", "cf", str(oracle), "-C", str(classes), "."], check=True)
+        for directory in ("selfhost", "compiler-plan"):
+            shutil.copytree(ROOT / directory, root / directory, ignore=shutil.ignore_patterns("build", ".dawn"))
+        (root / "packages").symlink_to(ROOT / "packages", target_is_directory=True)
+        fixture = root / "scripts/incremental-semantics-contract"
+        shutil.copytree(HERE, fixture)
+        (fixture / "src/reference.dawn").write_text((HERE / "reference-tests.dawn.txt").read_text())
+        driver = root / "selfhost/src/driver/analyze.dawn"
+        for name, source in subjects:
+            driver.write_text(source + "\n" + reference)
+            status, output = run("build", "--cp", oracle, fixture, "-o", root / "subject.jar")
+            if status:
+                raise RuntimeError(f"{name} did not compile\n{output}")
+            result = subprocess.run(["java", "-Xss64m", "-Xmx2g", "-cp",
+                                     str(oracle) + os.pathsep + str(root / "subject.jar"),
+                                     "contract.SemanticSnapshot"], cwd=ROOT, text=True,
+                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=300)
+            status, output = result.returncode, result.stdout
+            if name == "positive":
+                if status or not re.search(r"^PASS\s+.*" + re.escape(OWNER), output, re.M):
+                    raise RuntimeError(f"frozen-loop positive failed\n{output}")
+            elif not status or not re.search(r"^FAIL\s+.*" + re.escape(OWNER), output, re.M):
+                raise RuntimeError(f"{name} missed the frozen-loop assertion\n{output}")
+            print(f"OK: frozen-loop {name}", flush=True)
+    print(f"OK: full-product cold reference, 6 compiling mutants; elapsed={time.monotonic()-started:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/incremental-semantics-contract/dawn.toml
+++ b/scripts/incremental-semantics-contract/dawn.toml
@@ -3,3 +3,4 @@ name = "incremental_contract"
 
 [deps]
 compiler = "../../selfhost"
+compiler_plan = "../../compiler-plan"

--- a/scripts/incremental-semantics-contract/reference-loop.dawn.txt
+++ b/scripts/incremental-semantics-contract/reference-loop.dawn.txt
@@ -1,0 +1,90 @@
+# Frozen from 58ebd4a5 driver/analyze.dawn; only the entry name changed.
+# Injected into a private subject, never linked into the production compiler.
+pub fn analyze_reference(loaded: LoadResult, std: StdCtx, opts: CtOpts, js: Jsig) -> Program !Env !io = {
+  var diags = loaded.diags
+  var exports = std.exports
+  var out: List[CheckedMod] = []
+  # ids continue across modules so grafted ADT/trait ids never collide
+  var nid = std.next_id
+  # The program's impls, accumulated the way `exports` is -- but for a
+  # different reason. An export is reachable only through a `use`; an impl is
+  # in force everywhere (spec §3.5), so this table is not what the importer
+  # asked for, it is the whole program's.
+  #
+  # Dependency order is enough to have every impl that can matter: the orphan
+  # rule puts an impl in the module declaring the trait or the one declaring
+  # the subject, so a module able to name both has already been preceded by
+  # whichever of the two wrote it.
+  var impls = std.impls
+  for mf0 in loaded.modules {
+    # The one place a module's identity is settled, and the reason it is here
+    # rather than in the loaders: only this function holds the std, and the
+    # std is the only thing that can say whether a file on disk *is* std.
+    # The loaders answer from the source root, which makes `std/list.dawn`
+    # the module `list` and an editor buffer the module `main` -- both wrong
+    # for the bundled library's own sources, and wrong in the direction that
+    # takes the std-only surface away from the code that defines it.
+    let (mf, is_std) = std_identity(std, mf0)
+    for d in mf.pdiags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
+    let parse_failed = len(mf.pdiags) > 0
+    # A std source checked here is the bundle's own copy being checked a
+    # second time, so its baseline is the one `load_std` gave it -- what the
+    # modules before it declared -- and not the finished library, which holds
+    # the very impls this module is about to register.
+    var base_impls = impls
+    if is_std {
+      match map.get(std.impls_before, mf.mod_path) {
+        Some(before) -> { base_impls = before }
+        None -> ()
+      }
+    }
+    var cx = cx_new(Some(mf.class_name), Some(mf.path))
+    cx = Cx {
+      ..cx,
+      # the module's own name got a vote in `cx_new` and does not get one
+      # here: `src/std/foo.dawn` is spelled like std and is not std
+      is_std_module: is_std,
+      std_fns: std.std_fns,
+      moved: std.moved,
+      line_starts: lexer.line_starts_of(mf.text),
+      next_id: nid,
+      # std's impls are part of the baseline, not something `use` turns on --
+      # and neither are the ones the modules before this got to
+      impl_table: base_impls,
+      # the host's Java signature oracle: jreflect's on the JVM driver, the
+      # refusing default anywhere else (a native compiler refuses `use java`)
+      jsig: js
+    }
+    var tm = empty_tmodule()
+    var ct = empty_ctout()
+    if not parse_failed {
+      let (cx1, tm1) = check_module(cx, mf.m, exports)
+      cx = cx1
+      tm = tm1
+      if len(cx.diags) == 0 {
+        ct = eval_comptime(tm, std.fn_decls, std.by_owner, std.impl_fns, std.std_names,
+          cx.adts, cx.traits, cx.impl_table, mf.class_name, opts)
+      }
+      for d in cx.diags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
+      for d in ct.diags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
+    }
+    nid = cx.next_id
+    # registration already rejected anything that collided with a key already
+    # in this table, so every row here is either new or the one put there
+    for pr in map.entries(cx.impl_table) {
+      let (k, v) = pr
+      impls = map.insert(impls, k, v)
+    }
+    exports = map.insert(exports, mf.mod_path, exports_of(cx, mf.m, mf.mod_path, mf.class_name))
+    out = out ++ [CheckedMod {
+      mod_path: mf.mod_path,
+      class_name: mf.class_name,
+      path: mf.path,
+      m: mf.m,
+      cx: cx,
+      tm: tm,
+      ct: ct
+    }]
+  }
+  Program { modules: out, diags: diags }
+}

--- a/scripts/incremental-semantics-contract/reference-tests.dawn.txt
+++ b/scripts/incremental-semantics-contract/reference-tests.dawn.txt
@@ -1,0 +1,71 @@
+# Only compiled after the frozen loop is injected into a private driver.
+use std/io
+use compiler/front/parser
+use compiler/driver/analyze.{Program, LoadedModule, LoadResult, LocDiag, analyze_program, analyze_reference}
+use compiler/driver/stdlib.{load_std, std_load_error_text}
+use compiler/check/jsig.{jsig_refused}
+use compiler/ir/interp.{ct_default, ct_fuel}
+pub type Comparison = { old: Program, current: Program }
+
+fn input(name: String, text: String) -> LoadedModule = {
+  let (m, pd) = parser.parse_module(text)
+  LoadedModule {
+    mod_path: name, class_name: name, path: name ++ ".dawn",
+    text: text, m: m, pdiags: pd, pkg: None
+  }
+}
+
+pub fn sample_count(xs: List[Comparison]) -> Int = len(xs)
+
+pub fn sample_at(xs: List[Comparison], index: Int) -> Comparison = xs[index]
+
+pub fn samples() -> List[Comparison] !io = {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = match load_std("std") {
+      Ok(s) -> s
+      Err(e) -> panic(std_load_error_text(e))
+    }
+    let lib = input("lib",
+      "pub trait Sizey[T] { fn sizey(x: T) -> Int }\n" ++
+        "pub type Box = { n: Int } derive Show\n" ++
+        "impl Sizey[Box] { fn sizey(b: Box) -> Int = b.n + 2 }\n" ++
+        "pub fn describe[T: Sizey](x: T) -> Int = sizey(x)\n" ++
+        "pub const N: Int = 40 + 2\n")
+    let middle = input("middle", "pub type Other = { n: Int }\npub fn make() -> Other = Other { n: 7 }\n")
+    let consumer = input("consumer",
+      "use lib\nuse lib.{Box}\npub fn value() -> Int = lib.describe(Box { n: 3 })\n")
+    let bad = input("bad", "pub fn bad() -> Int = false\n")
+    let broken = input("broken", "pub fn (\n")
+    let loader = LocDiag { path: "loader", d: broken.pdiags[0] }
+    var results: List[Comparison] = []
+    let cases: List[LoadResult] = [
+      LoadResult { modules: [lib, middle, consumer], diags: [] },
+      LoadResult { modules: [bad, lib, consumer], diags: [loader] },
+      LoadResult { modules: [broken, lib, bad, consumer], diags: [] },
+      LoadResult { modules: [middle, lib, consumer], diags: [] },
+      LoadResult { modules: [lib], diags: [] },
+      LoadResult { modules: [], diags: [loader] }
+    ]
+    for loaded in cases {
+      for opts in [ct_default(), ct_fuel(0)] {
+        let old = analyze_reference(loaded, std, opts, jsig_refused())
+        let current = analyze_program(loaded, std, opts, jsig_refused())
+        results = results ++ [Comparison { old: old, current: current }]
+      }
+    }
+    let clean = analyze_reference(cases[0], std, ct_default(), jsig_refused())
+    if len(clean.diags) != 0 { panic("reference clean fixture has diagnostics") }
+    # std rechecking intentionally uses impls_before, not the final bundle.
+    let text = match io.read_file("std/list.dawn") {
+      Ok(t) -> t
+      Err(e) -> panic(e.message)
+    }
+    let list = LoadedModule { ..input("list", text), path: "std/list.dawn" }
+    let loaded = LoadResult { modules: [list], diags: [] }
+    let old = analyze_reference(loaded, std, ct_default(), jsig_refused())
+    let current = analyze_program(loaded, std, ct_default(), jsig_refused())
+    if len(old.diags) != 0 { panic("reference std fixture has diagnostics") }
+    results = results ++ [Comparison { old: old, current: current }]
+    results
+  }))
+}

--- a/scripts/incremental-semantics-contract/src/bench.dawn
+++ b/scripts/incremental-semantics-contract/src/bench.dawn
@@ -1,0 +1,99 @@
+# Emit raw per-round timings; aggregation and environment capture belong to
+# the runner. Loading includes source reads, parsing and graph construction.
+# The separate parse replay is labelled as such, never subtracted from load
+# to pretend it measures the loader's own parser interval.
+
+use std/io
+use compiler/driver/analyze.{
+  AnalysisObserver, AnalyzeModule, AnalyzeCheck, AnalyzeComptime,
+  project_plan, load_planned, analyze_observed, analyze_program
+}
+use compiler/driver/stdlib.{load_std, std_load_error_text}
+use compiler/front/parser
+use compiler/ir/interp.{ct_default}
+use compiler/jvm/jreflect.{jsig_for, query_probe}
+use compiler/pkg/maven
+use compiler_plan/source
+use java "java.lang.System"
+use java "java.util.concurrent.atomic.AtomicLong"
+
+type Timer = { start: AtomicLong, elapsed: AtomicLong, runs: AtomicLong }
+
+fn timer() -> Timer !io =
+  Timer { start: AtomicLong.new(0), elapsed: AtomicLong.new(0), runs: AtomicLong.new(0) }
+
+pub fn main() -> Unit !io =
+  io.with_fs_real(() => io.with_proc_real(() => io.with_env_real(() => {
+    let argv = args()
+    let target = if len(argv) > 0 { argv[0] } else { "examples/projects/calc.dawn" }
+    println("meta\tjava\t" ++ System.getProperty("java.version").expect("java.version"))
+    let std = match load_std("std") {
+      Ok(s) -> s
+      Err(e) -> panic(std_load_error_text(e))
+    }
+    let target_kind = if io.is_dir(target) { source.ProjectDirectory(target) } else { source.SourceFile(target) }
+    let plan = project_plan(target_kind)
+    let jars = match maven.fetch_checked_report(plan.source.project, plan.source.java_coords) {
+      Ok(found) -> found
+      Err(e) -> panic(e.message)
+    }
+    with held <- bracket(jsig_for(jars), lease => lease.close())
+    let js = held.jsig
+    var round = 0
+    while round < 11 {
+      let load_start = System.nanoTime()
+      let loaded = load_planned(plan)
+      let load_ns = System.nanoTime() - load_start
+      let parse_start = System.nanoTime()
+      var parsed_decls = 0
+      for m in loaded.modules {
+        let (parsed, diagnostics) = parser.parse_module(m.text)
+        parsed_decls = parsed_decls + len(parsed.decls) + len(diagnostics)
+      }
+      let parse_replay_ns = System.nanoTime() - parse_start
+      let module_timer = timer()
+      let check_timer = timer()
+      let ct_timer = timer()
+      let observer: AnalysisObserver = (name, stage, entering) => {
+        let t = match stage {
+          AnalyzeModule -> module_timer
+          AnalyzeCheck -> check_timer
+          AnalyzeComptime -> ct_timer
+        }
+        if entering {
+          t.start.set(System.nanoTime())
+        } else {
+          let _ = t.elapsed.addAndGet(System.nanoTime() - t.start.get())
+          let _ = t.runs.incrementAndGet()
+        }
+      }
+      let probe = query_probe(js)
+      # Alternate the order to avoid always giving cold the second-run advantage.
+      let (observed_ns, cold_ns, observed_diags, cold_diags) = if round % 2 == 0 {
+        let start = System.nanoTime()
+        let observed = analyze_observed(loaded, std, ct_default(), probe.jsig, Some(observer))
+        let elapsed = System.nanoTime() - start
+        let cold_start = System.nanoTime()
+        let cold = analyze_program(loaded, std, ct_default(), js)
+        (elapsed, System.nanoTime() - cold_start, len(observed.diags), len(cold.diags))
+      } else {
+        let start = System.nanoTime()
+        let cold = analyze_program(loaded, std, ct_default(), js)
+        let elapsed = System.nanoTime() - start
+        let observed_start = System.nanoTime()
+        let observed = analyze_observed(loaded, std, ct_default(), probe.jsig, Some(observer))
+        (System.nanoTime() - observed_start, elapsed, len(observed.diags), len(cold.diags))
+      }
+      println(join([
+        "round", to_string(round), target,
+        to_string(len(loaded.modules)), to_string(parsed_decls),
+        to_string(load_ns), to_string(parse_replay_ns), to_string(observed_ns),
+        to_string(module_timer.elapsed.get()), to_string(check_timer.elapsed.get()),
+        to_string(ct_timer.elapsed.get()), to_string(cold_ns),
+        to_string(check_timer.runs.get()), to_string(ct_timer.runs.get()),
+        to_string(probe.queries()), to_string(observed_diags), to_string(cold_diags),
+        if round % 2 == 0 { "observed-first" } else { "cold-first" }
+      ], "\t"))
+      round = round + 1
+    }
+  })))

--- a/scripts/incremental-semantics-contract/src/cold.dawn
+++ b/scripts/incremental-semantics-contract/src/cold.dawn
@@ -1,0 +1,117 @@
+# Hold the exact cold transition before allowing any result to be reused.
+# The trace is test-owned host state; production analysis has no observer.
+
+use std/map
+use std/io
+use compiler/front/parser
+use compiler/driver/analyze.{
+  LoadedModule, LoadResult, LocDiag, Program, AnalysisStage,
+  AnalyzeModule, AnalyzeCheck, AnalyzeComptime,
+  analyze_program, analyze_observed, analyze_module_step, initial_carry
+}
+use compiler/driver/stdlib.{StdCtx, load_std, std_load_error_text}
+use compiler/driver/checkdump
+use compiler/check/jsig.{jsig_refused}
+use compiler/ir/interp.{ct_default, ct_fuel}
+use std/io.{Fs, Env}
+use java "java.util.ArrayList"
+
+fn std_context() -> StdCtx !Fs !Env !io =
+  match load_std("std") {
+    Ok(s) -> s
+    Err(e) -> panic(std_load_error_text(e))
+  }
+
+fn source(name: String, text: String) -> LoadedModule = {
+  let (m, pdiags) = parser.parse_module(text)
+  LoadedModule {
+    mod_path: name, class_name: name, path: name ++ ".dawn",
+    text: text, m: m, pdiags: pdiags, pkg: None
+  }
+}
+
+fn stage_name(stage: AnalysisStage) -> String =
+  match stage {
+    AnalyzeModule -> "module"
+    AnalyzeCheck -> "check"
+    AnalyzeComptime -> "comptime"
+  }
+
+test "cold observation is nested and leaves the program unchanged" {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = std_context()
+    let m = source("answer", "pub fn answer() -> Int = 42\n")
+    let loaded = LoadResult { modules: [m], diags: [] }
+    let events = ArrayList.new()
+    let observed = analyze_observed(loaded, std, ct_default(), jsig_refused(),
+      Some((name, stage, entering) => {
+        let _ = events.add(name ++ ":" ++ stage_name(stage) ++ ":" ++ to_string(entering))
+      }))
+    let cold = analyze_program(loaded, std, ct_default(), jsig_refused())
+    assert checkdump.render(observed) == checkdump.render(cold)
+    assert observed.modules[0].tm == cold.modules[0].tm
+    assert observed.modules[0].cx.adts == cold.modules[0].cx.adts
+    assert len(observed.diags) == 0
+    assert events.toString().expect("trace") ==
+      "[answer:module:true, answer:check:true, answer:check:false, answer:comptime:true, answer:comptime:false, answer:module:false]"
+    let step = analyze_module_step(m, initial_carry(std), std, ct_default(), jsig_refused(), None)
+    assert step.check_runs == 1
+    assert step.comptime_runs == 1
+    assert step.after.next_id == cold.modules[0].cx.next_id
+    assert map.has(step.after.exports, "answer")
+  }))
+}
+
+test "failed cold steps retain exports and only run the reachable phases" {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = std_context()
+    let parse_error = source("parse_error", "pub fn broken(\n")
+    assert len(parse_error.pdiags) > 0
+    let events = ArrayList.new()
+    let parsed = analyze_module_step(parse_error, initial_carry(std), std, ct_default(), jsig_refused(),
+      Some((name, stage, entering) => {
+        let _ = events.add(stage_name(stage) ++ ":" ++ to_string(entering))
+      }))
+    assert parsed.check_runs == 0
+    assert parsed.comptime_runs == 0
+    assert len(parsed.diags) == len(parse_error.pdiags)
+    assert map.has(parsed.after.exports, "parse_error")
+    assert parsed.after.next_id == std.next_id
+    assert events.toString().expect("trace") == "[module:true, module:false]"
+
+    let type_error = source("type_error", "pub fn broken() -> Int = false\n")
+    let typed = analyze_module_step(type_error, parsed.after, std, ct_default(), jsig_refused(), None)
+    assert typed.check_runs == 1
+    assert typed.comptime_runs == 0
+    assert len(typed.diags) > 0
+    assert map.has(typed.after.exports, "type_error")
+    assert map.has(typed.after.exports, "parse_error")
+    assert typed.after.next_id == typed.checked.cx.next_id
+
+    let exhausted = source("exhausted", "pub const N: Int = 40 + 2\n")
+    let evaluated = analyze_module_step(exhausted, typed.after, std, ct_fuel(0), jsig_refused(), None)
+    assert evaluated.check_runs == 1
+    assert evaluated.comptime_runs == 1
+    assert len(evaluated.checked.cx.diags) == 0
+    assert len(evaluated.checked.ct.diags) > 0
+    assert map.has(evaluated.after.exports, "exhausted")
+  }))
+}
+
+test "cold program diagnostics start with the current loader result" {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = std_context()
+    let bad = source("bad", "pub fn broken() -> Int = false\n")
+    let (_, diagnostics) = parser.parse_module("pub fn (\n")
+    assert len(diagnostics) > 0
+    let loader = LocDiag { path: "loader", d: diagnostics[0] }
+    let loaded = LoadResult { modules: [bad], diags: [loader] }
+    let prog = analyze_program(loaded, std, ct_default(), jsig_refused())
+    let step = analyze_module_step(bad, initial_carry(std), std, ct_default(), jsig_refused(), None)
+    assert len(prog.diags) == len(step.diags) + 1
+    assert prog.diags[0].path == "loader"
+    assert prog.diags[1].path == "bad.dawn"
+    let assembled = Program { modules: [step.checked], diags: [loader] ++ step.diags }
+    assert checkdump.render(prog) == checkdump.render(assembled)
+  }))
+}

--- a/selfhost/src/driver/analyze.dawn
+++ b/selfhost/src/driver/analyze.dawn
@@ -31,7 +31,7 @@ use driver/stdlib.{
   StdCtx, load_std, std_load_error_text, std_module_of, is_std_dir, read_index
 }
 use check/tast.{TFun, TModule}
-use check/types.{Sym}
+use check/types.{Sym, Impls}
 use front/parser
 use front/lexer
 use fspath/fspath
@@ -707,6 +707,41 @@ pub type CheckedMod = {
 
 pub type Program = { modules: List[CheckedMod], diags: List[LocDiag] }
 
+## All state that advances between modules, including failed ones. An impl
+## is program-wide, not activated by an import; ids must keep their original
+## allocation order so metadata grafted by imports never collides.
+pub type AnalysisCarry = {
+  exports: Map[String, ModExports],
+  impls: Impls,
+  next_id: Int
+}
+
+## The enclosing module interval includes context construction and export
+## assembly. Check and comptime intervals are nested inside it, never overlap,
+## and are absent when the corresponding phase is skipped after an error.
+pub type AnalysisStage = AnalyzeModule | AnalyzeCheck | AnalyzeComptime
+pub alias AnalysisObserver = fn(String, AnalysisStage, Bool) -> Unit !io
+
+pub type ModuleStep = {
+  input: LoadedModule,
+  checked: CheckedMod,
+  diags: List[LocDiag],
+  after: AnalysisCarry,
+  check_runs: Int,
+  comptime_runs: Int
+}
+
+pub fn initial_carry(std: StdCtx) -> AnalysisCarry =
+  AnalysisCarry { exports: std.exports, impls: std.impls, next_id: std.next_id }
+
+fn analysis_event(
+  observer: Option[AnalysisObserver], name: String, stage: AnalysisStage, entering: Bool
+) -> Unit !io =
+  match observer {
+    Some(note) -> note(name, stage, entering)
+    None -> ()
+  }
+
 ## One editor analysis plus the source plan captured for project-aware
 ## completion. A truly standalone buffer has no project plan.
 pub type DocumentAnalysis = {
@@ -750,93 +785,122 @@ fn std_identity(std: StdCtx, mf: LoadedModule) -> (LoadedModule, Bool) !Env =
 
 ## Check a loaded program in dependency order: each module sees the exports of
 ## everything before it (std pre-seeded); comptime runs on clean modules only.
-pub fn analyze_program(loaded: LoadResult, std: StdCtx, opts: CtOpts, js: Jsig) -> Program !Env !io = {
+pub fn analyze_program(loaded: LoadResult, std: StdCtx, opts: CtOpts, js: Jsig) -> Program !Env !io =
+  analyze_observed(loaded, std, opts, js, None)
+
+## The cold path remains the production entry. Observation is opt-in and
+## cannot add diagnostics, change the wire protocol, or turn an error into a
+## cached success. The caller owns any timing and counter state.
+pub fn analyze_observed(
+  loaded: LoadResult, std: StdCtx, opts: CtOpts, js: Jsig,
+  observer: Option[AnalysisObserver]
+) -> Program !Env !io = {
   var diags = loaded.diags
-  var exports = std.exports
+  var carry = initial_carry(std)
   var out: List[CheckedMod] = []
-  # ids continue across modules so grafted ADT/trait ids never collide
-  var nid = std.next_id
-  # The program's impls, accumulated the way `exports` is -- but for a
-  # different reason. An export is reachable only through a `use`; an impl is
-  # in force everywhere (spec §3.5), so this table is not what the importer
-  # asked for, it is the whole program's.
-  #
-  # Dependency order is enough to have every impl that can matter: the orphan
-  # rule puts an impl in the module declaring the trait or the one declaring
-  # the subject, so a module able to name both has already been preceded by
-  # whichever of the two wrote it.
-  var impls = std.impls
-  for mf0 in loaded.modules {
-    # The one place a module's identity is settled, and the reason it is here
-    # rather than in the loaders: only this function holds the std, and the
-    # std is the only thing that can say whether a file on disk *is* std.
-    # The loaders answer from the source root, which makes `std/list.dawn`
-    # the module `list` and an editor buffer the module `main` -- both wrong
-    # for the bundled library's own sources, and wrong in the direction that
-    # takes the std-only surface away from the code that defines it.
-    let (mf, is_std) = std_identity(std, mf0)
-    for d in mf.pdiags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
-    let parse_failed = len(mf.pdiags) > 0
-    # A std source checked here is the bundle's own copy being checked a
-    # second time, so its baseline is the one `load_std` gave it -- what the
-    # modules before it declared -- and not the finished library, which holds
-    # the very impls this module is about to register.
-    var base_impls = impls
-    if is_std {
-      match map.get(std.impls_before, mf.mod_path) {
-        Some(before) -> { base_impls = before }
-        None -> ()
-      }
-    }
-    var cx = cx_new(Some(mf.class_name), Some(mf.path))
-    cx = Cx {
-      ..cx,
-      # the module's own name got a vote in `cx_new` and does not get one
-      # here: `src/std/foo.dawn` is spelled like std and is not std
-      is_std_module: is_std,
-      std_fns: std.std_fns,
-      moved: std.moved,
-      line_starts: lexer.line_starts_of(mf.text),
-      next_id: nid,
-      # std's impls are part of the baseline, not something `use` turns on --
-      # and neither are the ones the modules before this got to
-      impl_table: base_impls,
-      # the host's Java signature oracle: jreflect's on the JVM driver, the
-      # refusing default anywhere else (a native compiler refuses `use java`)
-      jsig: js
-    }
-    var tm = empty_tmodule()
-    var ct = empty_ctout()
-    if not parse_failed {
-      let (cx1, tm1) = check_module(cx, mf.m, exports)
-      cx = cx1
-      tm = tm1
-      if len(cx.diags) == 0 {
-        ct = eval_comptime(tm, std.fn_decls, std.by_owner, std.impl_fns, std.std_names,
-          cx.adts, cx.traits, cx.impl_table, mf.class_name, opts)
-      }
-      for d in cx.diags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
-      for d in ct.diags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
-    }
-    nid = cx.next_id
-    # registration already rejected anything that collided with a key already
-    # in this table, so every row here is either new or the one put there
-    for pr in map.entries(cx.impl_table) {
-      let (k, v) = pr
-      impls = map.insert(impls, k, v)
-    }
-    exports = map.insert(exports, mf.mod_path, exports_of(cx, mf.m, mf.mod_path, mf.class_name))
-    out = out ++ [CheckedMod {
-      mod_path: mf.mod_path,
-      class_name: mf.class_name,
-      path: mf.path,
-      m: mf.m,
-      cx: cx,
-      tm: tm,
-      ct: ct
-    }]
+  for mf in loaded.modules {
+    let step = analyze_module_step(mf, carry, std, opts, js, observer)
+    carry = step.after
+    diags = diags ++ step.diags
+    out = out ++ [step.checked]
   }
   Program { modules: out, diags: diags }
+}
+
+## One exact transition of the original loop. Even a parse failure publishes
+## its recovered exports and carry. Keep the full impl-table fold: local_impls
+## alone is not a proven delta for prelude registration or std rechecking.
+pub fn analyze_module_step(
+  mf0: LoadedModule, before: AnalysisCarry, std: StdCtx, opts: CtOpts,
+  js: Jsig, observer: Option[AnalysisObserver]
+) -> ModuleStep !Env !io = {
+  var diags: List[LocDiag] = []
+  # The one place a module's identity is settled, and the reason it is here
+  # rather than in the loaders: only this function holds the std, and the
+  # std is the only thing that can say whether a file on disk *is* std.
+  # The loaders answer from the source root, which makes `std/list.dawn`
+  # the module `list` and an editor buffer the module `main` -- both wrong
+  # for the bundled library's own sources, and wrong in the direction that
+  # takes the std-only surface away from the code that defines it.
+  let (mf, is_std) = std_identity(std, mf0)
+  analysis_event(observer, mf.mod_path, AnalyzeModule, true)
+  for d in mf.pdiags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
+  let parse_failed = len(mf.pdiags) > 0
+  # A std source checked here is the bundle's own copy being checked a
+  # second time, so its baseline is the one `load_std` gave it -- what the
+  # modules before it declared -- and not the finished library, which holds
+  # the very impls this module is about to register.
+  var base_impls = before.impls
+  if is_std {
+    match map.get(std.impls_before, mf.mod_path) {
+      Some(before) -> { base_impls = before }
+      None -> ()
+    }
+  }
+  var cx = cx_new(Some(mf.class_name), Some(mf.path))
+  cx = Cx {
+    ..cx,
+    # the module's own name got a vote in `cx_new` and does not get one
+    # here: `src/std/foo.dawn` is spelled like std and is not std
+    is_std_module: is_std,
+    std_fns: std.std_fns,
+    moved: std.moved,
+    line_starts: lexer.line_starts_of(mf.text),
+    next_id: before.next_id,
+    # std's impls are part of the baseline, not something `use` turns on --
+    # and neither are the ones the modules before this got to
+    impl_table: base_impls,
+    # the host's Java signature oracle: jreflect's on the JVM driver, the
+    # refusing default anywhere else (a native compiler refuses `use java`)
+    jsig: js
+  }
+  var tm = empty_tmodule()
+  var ct = empty_ctout()
+  var check_runs = 0
+  var comptime_runs = 0
+  if not parse_failed {
+    analysis_event(observer, mf.mod_path, AnalyzeCheck, true)
+    let (cx1, tm1) = check_module(cx, mf.m, before.exports)
+    check_runs = 1
+    analysis_event(observer, mf.mod_path, AnalyzeCheck, false)
+    cx = cx1
+    tm = tm1
+    if len(cx.diags) == 0 {
+      analysis_event(observer, mf.mod_path, AnalyzeComptime, true)
+      ct = eval_comptime(tm, std.fn_decls, std.by_owner, std.impl_fns, std.std_names,
+        cx.adts, cx.traits, cx.impl_table, mf.class_name, opts)
+      comptime_runs = 1
+      analysis_event(observer, mf.mod_path, AnalyzeComptime, false)
+    }
+    for d in cx.diags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
+    for d in ct.diags { diags = diags ++ [LocDiag { path: mf.path, d: d }] }
+  }
+  var impls = before.impls
+  # registration already rejected anything that collided with a key already
+  # in this table, so every row here is either new or the one put there
+  for pr in map.entries(cx.impl_table) {
+    let (k, v) = pr
+    impls = map.insert(impls, k, v)
+  }
+  let exports = map.insert(before.exports, mf.mod_path, exports_of(cx, mf.m, mf.mod_path, mf.class_name))
+  let checked = CheckedMod {
+    mod_path: mf.mod_path,
+    class_name: mf.class_name,
+    path: mf.path,
+    m: mf.m,
+    cx: cx,
+    tm: tm,
+    ct: ct
+  }
+  analysis_event(observer, mf.mod_path, AnalyzeModule, false)
+  ModuleStep {
+    input: mf,
+    checked: checked,
+    diags: diags,
+    after: AnalysisCarry { exports: exports, impls: impls, next_id: cx.next_id },
+    check_runs: check_runs,
+    comptime_runs: comptime_runs
+  }
 }
 
 # ---- single-document analysis (the language server's entry) ----


### PR DESCRIPTION
## 范围

增量语义引擎的冷路径前置：抽取 AnalysisCarry/ModuleStep，生产 analyze_program 仍走全量冷分析。新增显式 opt-in 阶段观测；没有启用缓存，也不宣称 Playground 提速。

## 正确性证据

- 从 58ebd4a5 冻结旧循环，在私有源码副本中对照相同 StdCtx、LoadedModule、CtOpts 的13组完整 Program/Cx。
- 独立 javac 结构比较器不依赖编译器生成的 Eq 字典；仅排除 Cx.jsig 能力和 Array 非逻辑 backing 状态。未知宿主对象 fail closed，包含比较器自检。
- 六个成功编译变异体分别破坏输入 ID、impl carry、诊断顺序、check/comptime 阶段跳过和 std baseline，全部命中语义差异。JDK21另行复跑通过。
- 618 selfhost、484 native、350 fixture、九个 Java probe 负控通过；自举 B==C 和独立 calc 发射通过。
- 完整 doc-check（132负控）、gatemap、budget（12负控）、fmt、Core 重录后复验通过。

## Core 审核

独立 4814d367 worktree dump 对照：driver.analyze 为本次实现变更；exitmem 的两处 handler ID 29374→29401；consolemem/lspq 仅生成 ADT 取号。17份固定 Core 文本未变，exact/norm 哈希按源码重录，未扩大归一化。

## 基准与 CI

可复现 runner 保存原始轮次、源码指纹、JDK/OS、交替顺序和进程 RSS；parse replay 不冒充 loader 内部分段，RSS 不冒充缓存保留内存。P1 的真实编辑/query/保留内存基线仍待补齐。

新增独立 incremental-semantics job，移出 contracts-1 中原 probe/fixture。整套本地81.07s，首次 CI 前规划预算 2×82+38=202s，timeout11min；等待准确 HEAD 的全部 CI 后再验收合并。
