### PR TITLE
Reuse verified module prefixes in LSP workspaces

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1040,13 +1040,12 @@ jobs:
     # not move.
   incremental-semantics:
     runs-on: ubuntu-latest
-    # Planning value until the first CI observation: the complete probe,
-    # frozen-loop mutants and inline suite took 81.07s locally on 2026-09-08.
-    # Double the rounded 82s for runner variance, plus 38s toolchain/checkout
-    # overhead observed for contracts-1: 202s. Keep this separate as the
-    # incremental contract grows rather than consuming contracts-1's budget.
-    # budget: 3x 202s planning value
-    timeout-minutes: 11
+    # Planning update: the original complete suite took 81.07s locally and
+    # the three workspace-owner mutants took 83.97s on 2026-09-08.
+    # Double rounded 82+84s, plus 38s fixed overhead: 370s.
+    # Engine prefix mutants have their own independent owning job below.
+    # budget: 3x 370s planning value
+    timeout-minutes: 19
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dawn-toolchain
@@ -1056,7 +1055,23 @@ jobs:
         run: |
           python3 scripts/incremental-semantics-contract/probe.py
           python3 scripts/incremental-semantics-contract/cold.py
+          python3 scripts/incremental-semantics-contract/lsp-prefix.py
           ./bin/dawn test scripts/incremental-semantics-contract
+
+  incremental-prefix:
+    runs-on: ubuntu-latest
+    # Full warm/frozen-cold products plus twelve compiling engine mutants:
+    # 242.59s locally on 2026-09-08; 2*243 + 38 = 524s planning value.
+    # This is a complete engine contract, not a shard of a shared matrix.
+    # budget: 3x 524s planning value
+    timeout-minutes: 27
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/dawn-toolchain
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: incremental prefix equivalence and execution counts
+        run: python3 scripts/incremental-semantics-contract/prefix.py
 
   contracts-1:
     runs-on: ubuntu-latest

--- a/docs/incremental-semantics-design.md
+++ b/docs/incremental-semantics-design.md
@@ -5,7 +5,7 @@
 
 ## 一、问题与基线
 
-调研基线为 `1ae9edf2`，实施基线已推进到 `3447a37b`。workspace 已复用 std、captured plan、Java lease，并有同步
+调研基线为 `1ae9edf2`，冷路径前置已合并到 `8c2312bc`。workspace 已复用 std、captured plan、Java lease，并有同步
 debounce 和一致 Program；缺的是跨编辑的语义复用。`driver/analyze.analyze_program`
 逐模块推进 exports、全局 impls 和 next_id，因此文本不变并不意味着模块结果可复用。
 Playground 使用非 file URI，属于 standalone；模块前缀复用不能加速每次都变的单模块。
@@ -56,7 +56,7 @@ inferred body 参与 signature，comptime 读取 body/value，不能只跟踪导
 | 期 | 交付 | 状态 |
 |---|---|---|
 | 1 | 冷路径对照、阶段基线、Java 观测 | 进行中 |
-| 2 | workspace 前缀缓存、生命周期、基本逐出 | 未开始；验收后报告 |
+| 2 | workspace 前缀缓存、生命周期、基本逐出 | 缓存及workspace接线已实现，验收进行中；验收后报告 |
 | 3 | 稳定身份、具名产物及重定位 | 未开始 |
 | 4 | query runtime、依赖失效和 header 接线 | 未开始 |
 | 5 | 函数 body 增量、standalone/Playground | 未开始；验收后报告 |
@@ -83,6 +83,25 @@ cold fold；阶段事件只由显式 `analyze_observed` 请求。私有夹具注
 程序的泛型 Eq 字典构造器问题，不改变生产发射。六个成功编译的变异体覆盖输入 ID、
 impl carry、诊断顺序、check/comptime 跳过和 std baseline；编译/反射错误不算负控。
 原始实现与独立循环的13组结果对拍、六个负控及350项夹具测试已在本地通过。
+
+后续实现使用 opaque `incremental.Session` 固定 world，防止旧 prefix 被拼接到新
+std/options/lease。Workspace 与 Program、entry map、diagnostics 同时提交新 Session；
+冲突快照逐出 replay，最后关闭文档沿既有路径移除整个 Workspace。JVM 提供真正的
+query_probe，native 提供 refused_probe。首版每个工作区最多保留128个模块和
+1,048,576个源码字符；这是逻辑留存预算，不是堆内存字节上界。只保留一代连续前缀，
+工具查询使用原 oracle，不保留本轮计数器。standalone 仍走旧入口。
+
+实测已证明少做工作，而不是仅凭耗时猜测命中：compiler-plan 的13模块编辑序列中，
+改最后一个 source 模块复用12、重查1；selfhost 的72模块 entry closure 中，
+改 main（位置71）复用26、重查46，Java查询阻断更长前缀；改 parser（位置3）
+只复用3、重查69。这里的72是LSP entry closure，不混称目录分析的74模块。
+
+同源码私有观测服务、GraalVM21.0.2、SerialGC、11轮丢前3轮的一组 compiler-plan
+对照：强制冷路径刷新中位119.19ms，前缀复用61.18ms。原始逐轮数据与限制在
+`scripts/incremental-semantics-contract/baselines/planner-20260908.json`；两边的全部
+hover/definition/completion回复一致。执行顺序为先cold进程后warm进程，样本少，
+不是通用加速倍数或SLA，RSS也不是缓存独占内存。较早与其他测试并行的hello_mod/selfhost
+延迟样本没有稳定提速结论，不能用于性能达标判断。
 
 首刀本地618个selfhost测试、集成套件214个测试、九个可编译负控和完整文档门通过。
 native侧484个selfhost测试通过，自举B==C固定点和独立calc发射冒烟通过；重录后Core门通过。

--- a/scripts/core-golden/selfhost.norm.sha
+++ b/scripts/core-golden/selfhost.norm.sha
@@ -13,7 +13,7 @@ f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.c
 32847738a975b9c9715fb1804dcac0008e3f60299d96977a516bd92ff72a4a6a  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-befaa5d9f392d37e8f717938e19af65783366dddeed68d40d1c3c361ec33eb78  ./dawn$pkg$compiler_plan.exitmem.core
+5d6f069517aa3cce2ff2697ffed3ac4cb35a1ef1dc0a6a665a47164b1da9b30c  ./dawn$pkg$compiler_plan.exitmem.core
 5e90809d7cf26b47edd232da9ed4d54e185dbaa36a4ee4b718a8c58bf6ee1c33  ./dawn$pkg$compiler_plan.manifestv.core
 f998cbf9d2c3c3712ac981592cf658f61944f43196b81f992b3d583794561297  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core
@@ -33,6 +33,7 @@ de72b0a760ab9d0fabf6a8efcee97555e23baef075eab4f04571f35391192114  ./doc.core
 c1418f11f19a6c34bdfadf7af36a38f56a67c97416d62e91b48f97a988ca1496  ./driver.analyze.core
 eeb8923f514acdf745419c3715a18b1ffa3b32919d92441996dfac199d7795d8  ./driver.checkdump.core
 0682165d07836cba6379f89941893f40c88c6f3df88c5c8571a328b1b812e2f3  ./driver.fsmem.core
+bb200e520f380a6bbd89c85388540d9d6800ab55471afebbf7cc0b185ec3ff0c  ./driver.incremental.core
 db1aa05296625cf27b1e8dd21494bbc33e78e04c654ca8fa73676bc059b430e7  ./driver.stdlib.core
 24fe929af4cdd666b7b27ea946ad4dd96482696718c5789cf447ce2bf5302912  ./embed.rtsrc.core
 5e5a2d98535d8893482dc433777f7511b2f316fee550419114798d11be64577c  ./embed.stdsrc.core
@@ -65,9 +66,9 @@ a453487ebbff8a1e04de17df359671b385074ea4a41beff0695a3a5d727ec2da  ./jvm.rtclasse
 2103a2252c3781229ed03c8ac7ad1098a1afae2f440077db2c7f10e3585ec485  ./jvm.testrun.core
 5c24f0465eb1d6d90b23acc324930b84dd4136f01234fc2aafc9f92eea49dee1  ./lsp.lspc.core
 43a1091b86e4935165db02dc82b77a5600bf35e87e0acbc6cee8376af51d22b6  ./lsp.lspq.core
-7a74a0bd319e3db2f00e0166e7beae3225da10cd81d5bdb6876b140baf03358b  ./lsp.server.core
-25338a87e3d6f379854729996330c5811fc7f46b4e4afdec0697e014db49f05f  ./main.core
-9669e751c94dae608ccbc455d381f82625fe07ff6be095175e78b6a1a1b83aee  ./nmain.core
+bf0bf0eaec4f70f82ed7ea7fbd5a713a82d62799769b27e588353508532dbbaf  ./lsp.server.core
+3ca59d02a276b5e5f2365079f68c763e72c9350aeed318c2a856ba55ca32c451  ./main.core
+4b0b36a34674ebab5a616e6765f56d6a1aab302aadb992633f60b80f18e50d62  ./nmain.core
 179fc22762af0ae49f61b97887ef20851a5772f81c0e0277a281600135dc1302  ./pkg.add.core
 d28c534bd99277de7ea14b5bae17cbc85fa461103d932d1adb83ecf4cd4d260b  ./pkg.maven.core
 669cb50f773c4baefe880dfb93ac91566f9d2958dc2938d34e3d745d52b6feca  ./pkg.vendor.core

--- a/scripts/core-golden/selfhost.sha
+++ b/scripts/core-golden/selfhost.sha
@@ -10,10 +10,10 @@ d55782f8e992c365f3feee140c163b7aaf4fc1e879746821d934a94aefdd68c7  ./c.rc.core
 ed2443ce9bf5757fae1b17937e79a1a1fddac93880b0a778c27b6eadb35d02f2  ./check.passes.core
 f1359689915b0e86f7db4f013a7313af0c11a5bc104ff05cc775f9f5c614296d  ./check.tast.core
 fb2393f9577ee9acb66a53802e0acf05cabf9f2b5e856c48e47573a1b342fd9c  ./check.types.core
-c7ebef95f88d6b6be7c1d66c122123861d3713cd157412007ab7606dcda3a849  ./dawn$pkg$compiler_plan.consolemem.core
+5178f714faa54548a6ec3f4ba5f09c56be14ed0dded6c49a8f31209190f54fc6  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-befaa5d9f392d37e8f717938e19af65783366dddeed68d40d1c3c361ec33eb78  ./dawn$pkg$compiler_plan.exitmem.core
+5d6f069517aa3cce2ff2697ffed3ac4cb35a1ef1dc0a6a665a47164b1da9b30c  ./dawn$pkg$compiler_plan.exitmem.core
 da4bcb58e63f8fce15fa28b5f49a2e9d366f77b3cbbb0264e79f86039f6ed537  ./dawn$pkg$compiler_plan.manifestv.core
 f998cbf9d2c3c3712ac981592cf658f61944f43196b81f992b3d583794561297  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core
@@ -33,6 +33,7 @@ de72b0a760ab9d0fabf6a8efcee97555e23baef075eab4f04571f35391192114  ./doc.core
 b9879dd76389481e4a5a1d2c1db2bdf36abeaf752350b93819c9aa78cb9fa47a  ./driver.analyze.core
 eeb8923f514acdf745419c3715a18b1ffa3b32919d92441996dfac199d7795d8  ./driver.checkdump.core
 0682165d07836cba6379f89941893f40c88c6f3df88c5c8571a328b1b812e2f3  ./driver.fsmem.core
+458ae7cfa539785103d9b7eaa7b872ed186236e6299338cffb129f1c71490f53  ./driver.incremental.core
 adda09359afeed9b853ca61b5cb54bf97b05d8af1bc4862da3cd88fcbed72d7a  ./driver.stdlib.core
 24fe929af4cdd666b7b27ea946ad4dd96482696718c5789cf447ce2bf5302912  ./embed.rtsrc.core
 5e5a2d98535d8893482dc433777f7511b2f316fee550419114798d11be64577c  ./embed.stdsrc.core
@@ -64,10 +65,10 @@ c1da51783bb4bc867d5ba841f62574789fdb69bcefd5bd962cae61ae4d2c01a9  ./jvm.ops.core
 a453487ebbff8a1e04de17df359671b385074ea4a41beff0695a3a5d727ec2da  ./jvm.rtclasses.core
 2103a2252c3781229ed03c8ac7ad1098a1afae2f440077db2c7f10e3585ec485  ./jvm.testrun.core
 e158469c2fdadd52d85f2505d424359cd521db8932476803dc55f75db6947340  ./lsp.lspc.core
-2fed4ff43a3049dc68c54f86ea32a09479a910c6a4e09ce2fe501d1b672d4a76  ./lsp.lspq.core
-7a74a0bd319e3db2f00e0166e7beae3225da10cd81d5bdb6876b140baf03358b  ./lsp.server.core
-446c4ef95202014677e3ccfc58ccd6a73aa2db9b69e37abcdd40edc76854abea  ./main.core
-9669e751c94dae608ccbc455d381f82625fe07ff6be095175e78b6a1a1b83aee  ./nmain.core
+906d57d8be4f65b971d92615b9aba7fa12321024d7d4ad3183f8db59e4535021  ./lsp.lspq.core
+bf0bf0eaec4f70f82ed7ea7fbd5a713a82d62799769b27e588353508532dbbaf  ./lsp.server.core
+a6949da489e8463284052e2333fe8529ed7c7baff7eebaa959192289aa70db48  ./main.core
+4b0b36a34674ebab5a616e6765f56d6a1aab302aadb992633f60b80f18e50d62  ./nmain.core
 f7592b074bb046a60900efb8e00a851a598d5b17cc1ff64363776fdcdf119ec5  ./pkg.add.core
 d28c534bd99277de7ea14b5bae17cbc85fa461103d932d1adb83ecf4cd4d260b  ./pkg.maven.core
 669cb50f773c4baefe880dfb93ac91566f9d2958dc2938d34e3d745d52b6feca  ./pkg.vendor.core

--- a/scripts/incremental-semantics-contract/README.md
+++ b/scripts/incremental-semantics-contract/README.md
@@ -38,4 +38,22 @@ python3 scripts/incremental-semantics-contract/bench.py \
 中跑11轮，丢前3轮，cold/observed 交替先后顺序。保存逐轮 TSV、源码 SHA-256、
 JDK/OS/参数、构建日志、摘要和进程峰值 RSS；每轮必须无诊断且所有模块执行 check/comptime。
 parse replay 不是 loader 内部分段，不能从 load 相减；RSS 包含启动、std 和整个进程，
-不是缓存保留内存。八个样本不足以声称稳定的加速倍数，也没有测量尚未实现的 warm 路径。
+不是缓存保留内存。八个样本不足以声称稳定的加速倍数；这个入口只测冷分析阶段。
+
+## 前缀与工作区
+
+`prefix.py` 对照完整 warm/frozen-cold 产品，覆盖12个可编译引擎负控，包括预算、
+std身份变化及构造器的负预算拒绝。`lsp-prefix.py` 覆盖三个工作区接线负控，要求
+owning FAIL 后是断言失败，不把 JVM 链接错误算作成功。工作区计数测试在共享server里，
+同时由 JVM/native selfhost 套件运行。原有 `scripts/lsp-workspace-contract/run.sh`
+另行守18个协议案例和20个资源/工作区负控，不能只靠新计数测试替代它。
+
+`lsp-bench.py` 通过实际 didChange overlay 编辑目标文件，磁盘源不改；
+立即跟 barrier 强制 flush，所以 sync 不包括空闲 debounce。随后单独测
+hover/definition/completion，并保存原始回复和 RSS。示例参数：
+`--entry <path> --edit <path> --needle <reference> --output <new-dir> -- <server-command>`。
+
+`lsp-observe.py --output <new-dir>` 构建私有服务器，在 stderr 记录最终模块顺序和
+实际复用/执行计数，不改变生产协议；`--cold` 只在私有副本里强制每轮先逐出 Session。
+两个模式都可用同一源码、JDK和编辑序列对照，回复必须相同。强制cold仍可能保留本轮
+输出prefix，不能用这两者的RSS差直接估算缓存大小。baseline JSON明确记录样本与限制。

--- a/scripts/incremental-semantics-contract/baselines/planner-20260908.json
+++ b/scripts/incremental-semantics-contract/baselines/planner-20260908.json
@@ -1,0 +1,575 @@
+{
+  "subject": {
+    "repository": "dawnop/dawn-lang",
+    "revision": "4814d367493c4421f10e7dba36d436783e873911",
+    "entry": "compiler-plan/src/source.dawn",
+    "edit": "compiler-plan/src/source.dawn",
+    "query": "source_roots(target)",
+    "modules": 13,
+    "first_changed_index": 12
+  },
+  "artifacts": {
+    "candidate_source_base": "8c2312bc13d815eb874c472a4ec8eeb90a885cf4",
+    "candidate_note": "Base plus the prefix implementation in the commit containing this record",
+    "cold_compiler_sha256": "8487027485f41ed7e40227b8a788e878cf058c1ad8b639f0898935079f8dce22",
+    "warm_compiler_sha256": "e0a182cdc36974fcc290366f04eae39a4ae6d4b493f0fe6bb4ede0029a457292",
+    "cold_instrumented_server_sha256": "577849b339a89e29b37af6a36437396ebe72d20a31115bd993cf67fb00b1b529",
+    "warm_instrumented_server_sha256": "4aaa3b1d750f9af8c0239d384ac1f881a992943567e8bce4dfcd905c07b916b4"
+  },
+  "environment": {
+    "jvm": "GraalVM Community OpenJDK 21.0.2",
+    "flags": [
+      "-Xss512m",
+      "-Xmx2g",
+      "-XX:+UseSerialGC"
+    ],
+    "os": "Linux x86_64 WSL2"
+  },
+  "method": {
+    "rounds": 11,
+    "discard_first": 3,
+    "order": "cold JVM then warm JVM",
+    "sync": "didChange through immediate unknown-request flush barrier; excludes idle debounce",
+    "queries": "hover, definition, completion on the resulting snapshot",
+    "cold": "same candidate with input session evicted before every analysis; output prefix may still be retained",
+    "instrumentation": "private lsp-observe.py module-order/count stderr instrumentation",
+    "limitations": [
+      "one process per mode; not an SLA or confidence interval",
+      "RSS is process-wide, not retained cache memory",
+      "fixed process order can bias timing; no universal speedup claim"
+    ],
+    "reply_comparison": "all 11 rounds identical after removing timing, memory and count fields"
+  },
+  "cold": [
+    {
+      "round": 0,
+      "sync_ns": 175313809,
+      "query_ns": {
+        "hover": 15297312,
+        "definition": 10239017,
+        "completion": 29549551
+      },
+      "rss": {
+        "VmHWM": "402264 kB",
+        "VmRSS": "394748 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 1,
+      "sync_ns": 148605194,
+      "query_ns": {
+        "hover": 7727517,
+        "definition": 5415465,
+        "completion": 11801421
+      },
+      "rss": {
+        "VmHWM": "445752 kB",
+        "VmRSS": "445752 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 2,
+      "sync_ns": 145679057,
+      "query_ns": {
+        "hover": 4926983,
+        "definition": 4006933,
+        "completion": 20635315
+      },
+      "rss": {
+        "VmHWM": "448308 kB",
+        "VmRSS": "444576 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 3,
+      "sync_ns": 135721047,
+      "query_ns": {
+        "hover": 3714805,
+        "definition": 3045840,
+        "completion": 8092277
+      },
+      "rss": {
+        "VmHWM": "467392 kB",
+        "VmRSS": "448732 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 4,
+      "sync_ns": 124230824,
+      "query_ns": {
+        "hover": 3544762,
+        "definition": 2455068,
+        "completion": 17885451
+      },
+      "rss": {
+        "VmHWM": "467392 kB",
+        "VmRSS": "463896 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 5,
+      "sync_ns": 128508831,
+      "query_ns": {
+        "hover": 4857980,
+        "definition": 3732487,
+        "completion": 10112935
+      },
+      "rss": {
+        "VmHWM": "472744 kB",
+        "VmRSS": "472512 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 6,
+      "sync_ns": 118147024,
+      "query_ns": {
+        "hover": 3056211,
+        "definition": 2688143,
+        "completion": 18705780
+      },
+      "rss": {
+        "VmHWM": "483204 kB",
+        "VmRSS": "483204 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 7,
+      "sync_ns": 117126491,
+      "query_ns": {
+        "hover": 3299676,
+        "definition": 2137230,
+        "completion": 8485635
+      },
+      "rss": {
+        "VmHWM": "497824 kB",
+        "VmRSS": "497824 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 8,
+      "sync_ns": 116322421,
+      "query_ns": {
+        "hover": 3049322,
+        "definition": 2046048,
+        "completion": 17771659
+      },
+      "rss": {
+        "VmHWM": "527332 kB",
+        "VmRSS": "527332 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 9,
+      "sync_ns": 115399082,
+      "query_ns": {
+        "hover": 2606079,
+        "definition": 2746213,
+        "completion": 7513494
+      },
+      "rss": {
+        "VmHWM": "532200 kB",
+        "VmRSS": "530124 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    },
+    {
+      "round": 10,
+      "sync_ns": 120230982,
+      "query_ns": {
+        "hover": 2458197,
+        "definition": 1973726,
+        "completion": 17448032
+      },
+      "rss": {
+        "VmHWM": "535636 kB",
+        "VmRSS": "532336 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 0,
+        "checked": 13,
+        "retained": 13
+      }
+    }
+  ],
+  "warm": [
+    {
+      "round": 0,
+      "sync_ns": 92854093,
+      "query_ns": {
+        "hover": 17184156,
+        "definition": 9740124,
+        "completion": 32210216
+      },
+      "rss": {
+        "VmHWM": "417568 kB",
+        "VmRSS": "412836 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 1,
+      "sync_ns": 67746905,
+      "query_ns": {
+        "hover": 15250320,
+        "definition": 5224161,
+        "completion": 11616770
+      },
+      "rss": {
+        "VmHWM": "426008 kB",
+        "VmRSS": "416252 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 2,
+      "sync_ns": 67076320,
+      "query_ns": {
+        "hover": 4981266,
+        "definition": 4127294,
+        "completion": 17403393
+      },
+      "rss": {
+        "VmHWM": "426520 kB",
+        "VmRSS": "426520 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 3,
+      "sync_ns": 56344002,
+      "query_ns": {
+        "hover": 4498764,
+        "definition": 11274681,
+        "completion": 9216403
+      },
+      "rss": {
+        "VmHWM": "434256 kB",
+        "VmRSS": "434256 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 4,
+      "sync_ns": 67252944,
+      "query_ns": {
+        "hover": 4094755,
+        "definition": 2371095,
+        "completion": 8051385
+      },
+      "rss": {
+        "VmHWM": "448312 kB",
+        "VmRSS": "448312 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 5,
+      "sync_ns": 66091757,
+      "query_ns": {
+        "hover": 3904181,
+        "definition": 3155432,
+        "completion": 17458594
+      },
+      "rss": {
+        "VmHWM": "455160 kB",
+        "VmRSS": "446464 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 6,
+      "sync_ns": 52376760,
+      "query_ns": {
+        "hover": 12486149,
+        "definition": 2803775,
+        "completion": 9251203
+      },
+      "rss": {
+        "VmHWM": "471728 kB",
+        "VmRSS": "471728 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 7,
+      "sync_ns": 60741104,
+      "query_ns": {
+        "hover": 3367038,
+        "definition": 3028021,
+        "completion": 16184023
+      },
+      "rss": {
+        "VmHWM": "481912 kB",
+        "VmRSS": "481912 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 8,
+      "sync_ns": 54691023,
+      "query_ns": {
+        "hover": 3897830,
+        "definition": 11666879,
+        "completion": 8426054
+      },
+      "rss": {
+        "VmHWM": "480464 kB",
+        "VmRSS": "478996 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 9,
+      "sync_ns": 61618153,
+      "query_ns": {
+        "hover": 3263616,
+        "definition": 2813014,
+        "completion": 8111808
+      },
+      "rss": {
+        "VmHWM": "492908 kB",
+        "VmRSS": "490680 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    },
+    {
+      "round": 10,
+      "sync_ns": 64170904,
+      "query_ns": {
+        "hover": 3184369,
+        "definition": 3197339,
+        "completion": 23622633
+      },
+      "rss": {
+        "VmHWM": "492908 kB",
+        "VmRSS": "485612 kB"
+      },
+      "load_average": [
+        0.46923828125,
+        0.5400390625,
+        1.14306640625
+      ],
+      "edited_module_index": 12,
+      "prefix_counts": {
+        "reused": 12,
+        "checked": 1,
+        "retained": 13
+      }
+    }
+  ]
+}

--- a/scripts/incremental-semantics-contract/lsp-bench.py
+++ b/scripts/incremental-semantics-contract/lsp-bench.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Measure real overlay edits and ready-snapshot queries without changing files.
+
+The barrier forces pending sync to flush, so edit latency excludes the idle
+debounce timer. Query timings are subsequent requests against that snapshot.
+Linux RSS is process memory, not a claim about retained semantic-cache bytes.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import statistics
+import sys
+import time
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts/lsp-workspace-contract"))
+from workspace import LspClient, did_open, did_change, position
+
+
+def rss(pid):
+    path = Path(f"/proc/{pid}/status")
+    if not path.exists():
+        return None
+    return {line.split(":")[0]: line.split(":", 1)[1].strip()
+            for line in path.read_text().splitlines() if line.startswith(("VmRSS:", "VmHWM:"))}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--entry", required=True, type=Path)
+    parser.add_argument("--edit", action="append", required=True, type=Path)
+    parser.add_argument("--needle", required=True, help="hover/definition target in entry source")
+    parser.add_argument("--output", required=True, type=Path, help="new directory")
+    parser.add_argument("--rounds", type=int, default=11)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    if not command or args.rounds < 4:
+        parser.error("provide a server command after -- and at least four rounds")
+    files = list(dict.fromkeys(path.resolve() for path in [args.entry, *args.edit]))
+    texts = {path: path.read_text() for path in files}
+    entry = args.entry.resolve()
+    target_position = position(texts[entry], args.needle)
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    metadata = {
+        "command": command, "cwd": str(ROOT), "platform": platform.platform(),
+        "warmup_rounds": 3, "rounds": args.rounds,
+        "sources": {str(path): hashlib.sha256(text.encode()).hexdigest() for path, text in texts.items()},
+        "note": "overlay-only comment edits; barrier excludes debounce; RSS is process-wide",
+    }
+    (output / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    client = LspClient(command, ROOT)
+    rows = []
+    try:
+        client.initialize()
+        mark = client.mark()
+        for path in files:
+            client.send(did_open(path.as_uri(), texts[path]))
+        initial = client.barrier(mark)
+        if any(item.get("params", {}).get("diagnostics") for item in initial
+               if item.get("method") == "textDocument/publishDiagnostics"):
+            raise RuntimeError(f"baseline contains diagnostics: {initial!r}")
+        for round_index in range(args.rounds):
+            for path in args.edit:
+                path = path.resolve()
+                mark = client.mark()
+                stderr_mark = len(client.stderr_text())
+                start = time.perf_counter_ns()
+                client.send(did_change(path.as_uri(), texts[path] + f"\n# benchmark edit {round_index}\n",
+                                       round_index + 2))
+                frames = client.barrier(mark)
+                elapsed = time.perf_counter_ns() - start
+                if any(item.get("params", {}).get("diagnostics") for item in frames
+                       if item.get("method") == "textDocument/publishDiagnostics"):
+                    raise RuntimeError(f"edit produced diagnostics: {frames!r}")
+                row = {"round": round_index, "edited": str(path), "sync_ns": elapsed,
+                       "rss": rss(client.proc.pid), "replies": {}, "query_ns": {},
+                       "load_average": os.getloadavg() if hasattr(os, "getloadavg") else None}
+                trace = client.stderr_text()[stderr_mark:].splitlines()
+                orders = [line.split("\t")[1:] for line in trace if line.startswith("LSP_INPUTS\t")]
+                counts = [line.split("\t")[1:] for line in trace if line.startswith("LSP_PREFIX_STATS\t")]
+                if orders:
+                    if len(orders) != 1:
+                        raise RuntimeError("expected one analysis input trace per edit")
+                    row["module_order"] = orders[0]
+                    row["edited_module_index"] = orders[0].index(str(path))
+                if counts:
+                    if len(counts) != 1 or len(counts[0]) != 3:
+                        raise RuntimeError("invalid prefix execution trace")
+                    row["prefix_counts"] = dict(zip(("reused", "checked", "retained"), map(int, counts[0])))
+                for method in ("hover", "definition", "completion"):
+                    start = time.perf_counter_ns()
+                    reply = client.result("textDocument/" + method, {
+                        "textDocument": {"uri": entry.as_uri()}, "position": target_position})
+                    row["query_ns"][method] = time.perf_counter_ns() - start
+                    row["replies"][method] = reply
+                if row["replies"]["hover"] is None:
+                    raise RuntimeError("hover target did not resolve; choose a real reference")
+                rows.append(row)
+                (output / "samples.json").write_text(json.dumps(rows, indent=2) + "\n")
+        client.shutdown_exit()
+    finally:
+        (output / "stderr.txt").write_text(client.stderr_text())
+        client.close()
+    summary = []
+    for path in args.edit:
+        samples = [row for row in rows if row["edited"] == str(path.resolve()) and row["round"] >= 3]
+        summary.append({
+            "edited": str(path.resolve()), "samples": len(samples),
+            "sync_median_ms": statistics.median(row["sync_ns"] for row in samples) / 1e6,
+            "query_median_ms": {method: statistics.median(row["query_ns"][method] for row in samples) / 1e6
+                                for method in ("hover", "definition", "completion")},
+        })
+    (output / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/incremental-semantics-contract/lsp-observe.py
+++ b/scripts/incremental-semantics-contract/lsp-observe.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Build a private LSP with module-order and execution-count traces on stderr.
+
+Production has no additional wire method or logging switch. The source root
+may be a frozen cold worktree or the candidate; both get the same input trace.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+from cold import DAWN, ROOT, edit
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, default=ROOT)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--cold", action="store_true",
+                        help="force eviction before each analysis in the private candidate")
+    args = parser.parse_args()
+    source = args.source.resolve()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    fingerprints = {}
+    for directory in ("selfhost", "compiler-plan"):
+        shutil.copytree(source / directory, output / directory,
+                        ignore=shutil.ignore_patterns("build", ".dawn"))
+        for path in sorted((source / directory).rglob("*")):
+            if path.is_file() and path.suffix in (".dawn", ".toml", ".lock"):
+                fingerprints[str(path.relative_to(source))] = hashlib.sha256(path.read_bytes()).hexdigest()
+    (output / "packages").symlink_to(source / "packages", target_is_directory=True)
+    server = output / "selfhost/src/lsp/server.dawn"
+    text = server.read_text()
+    anchor = "      let loaded = load_entries_over(ws0.plan, entries, overlay)"
+    text = edit(text, anchor, anchor + '''
+      var trace_paths: List[String] = []
+      for input in loaded.modules { trace_paths = trace_paths ++ [input.path] }
+      io.eprintln("LSP_INPUTS\\t" ++ join(trace_paths, "\\t"))''')
+    incremental = "      let update = incremental.analyze(ws0.cache, loaded)"
+    if incremental in text:
+        text = edit(text, incremental, incremental + '''
+      io.eprintln("LSP_PREFIX_STATS\\t" ++ to_string(update.stats.reused_modules) ++ "\\t" ++
+        to_string(update.stats.checked_modules) ++ "\\t" ++ to_string(update.stats.retained_modules))''')
+        if args.cold:
+            text = edit(text, "incremental.analyze(ws0.cache, loaded)",
+                        "incremental.analyze(incremental.evict(ws0.cache), loaded)")
+    elif args.cold:
+        raise RuntimeError("--cold requires a candidate with an incremental workspace")
+    server.write_text(text)
+    with (output / "build.log").open("w") as log:
+        subprocess.run([DAWN, "build", str(output / "selfhost"), "-o", str(output / "compiler.jar"),
+                        "--vendor", "org/objectweb/asm", "--vendor", "coursierapi"],
+                       cwd=ROOT, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=600)
+    (output / "metadata.json").write_text(json.dumps({
+        "source": str(source), "sources": fingerprints, "forced_cold": args.cold,
+        "instrumented_server_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "compiler_sha256": hashlib.sha256((output / "compiler.jar").read_bytes()).hexdigest(),
+    }, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/incremental-semantics-contract/lsp-prefix.py
+++ b/scripts/incremental-semantics-contract/lsp-prefix.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Prove that the workspace commits and discards the actual replay owner.
+
+The owning test uses in-memory Fs/Env and can also run in the native suite.
+Protocol-only comparisons would accept a server that silently always checks.
+"""
+from pathlib import Path
+import re
+import shutil
+import tempfile
+import time
+
+from cold import ROOT, edit, run
+
+OWNER = "workspace commits prefix cache with its Program and drops it on conflict"
+
+
+def main():
+    start = time.monotonic()
+    original = (ROOT / "selfhost/src/lsp/server.dawn").read_text()
+    variants = [
+        ("drop-session", "        cache: update.session,", "        cache: ws0.cache,"),
+        ("bypass-cache", "incremental.analyze(ws0.cache, loaded)",
+         "incremental.analyze(incremental.evict(ws0.cache), loaded)"),
+        ("keep-conflict-cache", "        cache: incremental.evict(ws0.cache),",
+         "        cache: ws0.cache,"),
+    ]
+    subjects = [("positive", original)] + [(name, edit(original, old, new)) for name, old, new in variants]
+    with tempfile.TemporaryDirectory(prefix="dawn-lsp-prefix-") as temp:
+        root = Path(temp)
+        for directory in ("selfhost", "compiler-plan"):
+            shutil.copytree(ROOT / directory, root / directory, ignore=shutil.ignore_patterns("build", ".dawn"))
+        (root / "packages").symlink_to(ROOT / "packages", target_is_directory=True)
+        target = root / "selfhost"
+        for name, source in subjects:
+            (target / "src/lsp/server.dawn").write_text(source)
+            status, output = run("check", target)
+            if status:
+                raise RuntimeError(f"{name} did not compile\n{output}")
+            status, output = run("test", target)
+            if name == "positive":
+                if status or not re.search(r"^PASS\s+lsp/server :: " + re.escape(OWNER), output, re.M):
+                    raise RuntimeError(f"positive failed\n{output}")
+            elif not status or not re.search(
+                    r"^FAIL\s+lsp/server :: " + re.escape(OWNER) + r"\n\s+assertion failed:", output, re.M):
+                raise RuntimeError(f"{name} missed the owning assertion\n{output}")
+            print(f"OK: workspace prefix {name}", flush=True)
+    print(f"OK: 3 compiling workspace cache mutants; elapsed={time.monotonic()-start:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/incremental-semantics-contract/prefix.py
+++ b/scripts/incremental-semantics-contract/prefix.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Compare warm sessions with the frozen cold loop and prove real cache hits.
+
+Each mutation is built before either owning assertion is evaluated. Runtime
+linkage errors and timeouts never substitute for a cache-contract failure.
+"""
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+
+from cold import ROOT, HERE, OWNER, edit, run
+
+
+def owning_assertion(output):
+    return bool(re.search(
+        r"^FAIL\s+prefix :: prefix cache [^\n]*\n\s+assertion failed:", output, re.M))
+
+
+def main():
+    assert owning_assertion("FAIL  prefix :: prefix cache control\n      assertion failed: expected hit\n")
+    assert not owning_assertion("FAIL  prefix :: prefix cache control\n      NoSuchMethodError\n")
+    assert not owning_assertion("FAIL  elsewhere :: prefix cache control\n      assertion failed: x\n")
+    reference = (HERE / "reference-tests.dawn.txt").read_text()
+    reference = edit(reference, "use std/io\n",
+                     "use std/io\nuse compiler/driver/incremental\n")
+    reference = edit(reference, "use compiler/check/jsig.{jsig_refused}",
+                     "use compiler/check/jsig.{jsig_refused, refused_probe}")
+    reference = edit(reference, "    for loaded in cases {\n      for opts in [ct_default(), ct_fuel(0)] {",
+                     "    for opts in [ct_default(), ct_fuel(0)] {\n"
+                     "      var owner = incremental.new(std, opts, jsig_refused(), refused_probe, 100, 100000)\n"
+                     "      for loaded in cases {")
+    reference = edit(reference,
+                     "        let current = analyze_program(loaded, std, opts, jsig_refused())",
+                     "        let first = incremental.analyze(owner, loaded)\n"
+                     "        let warm = incremental.analyze(first.session, loaded)\n"
+                     "        owner = warm.session\n"
+                     "        let current = warm.program")
+    reference = edit(reference,
+                     "    let current = analyze_program(loaded, std, ct_default(), jsig_refused())",
+                     "    let owner = incremental.new(std, ct_default(), jsig_refused(), refused_probe, 100, 100000)\n"
+                     "    let first = incremental.analyze(owner, loaded)\n"
+                     "    let current = incremental.analyze(first.session, loaded).program")
+    original = (ROOT / "selfhost/src/driver/incremental.dawn").read_text()
+    variants = [
+        ("always-cold", "    let hit = matching &&", "    let hit = false &&"),
+        ("text-only", "a == b", "a.text == b.text"),
+        ("resume-suffix", "      matching = false\n", "      ()\n"),
+        ("cache-errors", "len(computed.diags) != 0 || ", ""),
+        ("cache-java", " || probe.queries() != queries_before", ""),
+        ("ignore-loader", "len(loaded.diags) == 0 && ", ""),
+        ("ignore-ffi", "not session.opts.ffi", "true"),
+        ("ignore-eviction", "  State { ..session, prefix: [] }", "  session"),
+        ("ignore-module-budget", "len(prefix) < session.max_modules", "true"),
+        ("ignore-text-budget", "units <= session.max_text_units - text_units", "true"),
+        ("ignore-std-identity", "identity == session.prefix[index].std_identity", "true"),
+        ("allow-negative-budget",
+         '  if max_modules < 0 || max_text_units < 0 { panic("negative analysis cache limit") }',
+         "  ()"),
+    ]
+    subjects = [("positive", original)] + [(name, edit(original, old, new)) for name, old, new in variants]
+    with tempfile.TemporaryDirectory(prefix="dawn-prefix-reference-") as temp:
+        root = Path(temp)
+        classes = root / "classes"
+        classes.mkdir()
+        subprocess.run(["javac", "--release", "21", "-d", str(classes),
+                        str(HERE / "SemanticSnapshot.java")], check=True)
+        oracle = root / "snapshot.jar"
+        subprocess.run(["jar", "cf", str(oracle), "-C", str(classes), "."], check=True)
+        for directory in ("selfhost", "compiler-plan"):
+            shutil.copytree(ROOT / directory, root / directory, ignore=shutil.ignore_patterns("build", ".dawn"))
+        (root / "packages").symlink_to(ROOT / "packages", target_is_directory=True)
+        fixture = root / "scripts/incremental-semantics-contract"
+        shutil.copytree(HERE, fixture)
+        (fixture / "src/reference.dawn").write_text(reference)
+        driver = root / "selfhost/src/driver/analyze.dawn"
+        driver.write_text(driver.read_text() + "\n" + (HERE / "reference-loop.dawn.txt").read_text())
+        for name, source in subjects:
+            (root / "selfhost/src/driver/incremental.dawn").write_text(source)
+            status, output = run("build", fixture, "-o", root / "subject.jar")
+            if status:
+                raise RuntimeError(f"{name} did not compile\n{output}")
+            result = subprocess.run(["java", "-Xss64m", "-Xmx2g", "-cp",
+                                     str(oracle) + os.pathsep + str(root / "subject.jar"),
+                                     "contract.SemanticSnapshot"], cwd=ROOT, text=True,
+                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=300)
+            semantic_failure = result.returncode and re.search(
+                r"^FAIL\s+reference :: " + re.escape(OWNER), result.stdout, re.M)
+            if result.returncode and not semantic_failure:
+                raise RuntimeError(f"{name} oracle execution failed\n{result.stdout}")
+            status, output = run("test", fixture)
+            count_failure = status and owning_assertion(output)
+            if name == "positive":
+                if result.returncode or status:
+                    raise RuntimeError(f"positive failed\n{result.stdout}\n{output}")
+            elif not semantic_failure and not count_failure:
+                raise RuntimeError(f"{name} missed both owning assertions\n{result.stdout}\n{output}")
+            print(f"OK: prefix {name}", flush=True)
+    print(f"OK: full-product warm/cold reference and {len(variants)} compiling cache mutants")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/incremental-semantics-contract/src/prefix.dawn
+++ b/scripts/incremental-semantics-contract/src/prefix.dawn
@@ -1,0 +1,166 @@
+# Execution counts prove actual reuse; same-version cold comparison separately
+# guards output assembly. Full structural comparison lives in the private oracle.
+
+use std/io
+use compiler/driver/incremental
+use compiler/driver/analyze.{LoadedModule, LoadResult, LocDiag, analyze_program}
+use compiler/driver/stdlib.{load_std, std_load_error_text}
+use compiler/driver/checkdump
+use compiler/check/jsig.{jsig_refused, refused_probe}
+use compiler/ir/interp.{CtOpts, ct_default}
+use compiler/front/parser
+use compiler/jvm/jreflect.{jsig_real, query_probe}
+use compiler_plan/envmem
+
+fn source(name: String, text: String) -> LoadedModule = {
+  let (m, pdiags) = parser.parse_module(text)
+  LoadedModule {
+    mod_path: name, class_name: name, path: name ++ ".dawn",
+    text: text, m: m, pdiags: pdiags, pkg: None
+  }
+}
+
+test "prefix cache reuses only the unchanged initial sequence" {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = match load_std("std") {
+      Ok(s) -> s
+      Err(e) -> panic(std_load_error_text(e))
+    }
+    let a = source("a", "pub type Box = { n: Int }\n")
+    let b = source("b", "pub type Other = { n: Int }\n")
+    let c = source("c", "use a.{Box}\npub fn value() -> Box = Box { n: 1 }\n")
+    let d = source("d", "pub fn extra() -> Int = 4\n")
+    let loaded = LoadResult { modules: [a, b, c], diags: [] }
+    let fresh = incremental.new(std, ct_default(), jsig_refused(), refused_probe, 10, 10000)
+    let first = incremental.analyze(fresh, loaded)
+    assert first.stats.reused_modules == 0
+    assert first.stats.checked_modules == 3
+    assert first.stats.retained_modules == 3
+    let warm = incremental.analyze(first.session, loaded)
+    assert warm.stats.reused_modules == 3
+    assert warm.stats.checked_modules == 0
+    assert warm.stats.comptime_modules == 0
+    let edited = source("c", "use a.{Box}\npub fn value() -> Box = Box { n: 2 }\n")
+    let edits = [
+      LoadResult { modules: [a, b, edited], diags: [] },
+      LoadResult { modules: [a, c], diags: [] },
+      LoadResult { modules: [b, a, c], diags: [] },
+      LoadResult { modules: [a, b, c, d], diags: [] },
+      LoadResult { modules: [], diags: [] }
+    ]
+    let expected_hits = [2, 1, 0, 3, 0]
+    var i = 0
+    for input in edits {
+      let result = incremental.analyze(warm.session, input)
+      let cold = analyze_program(input, std, ct_default(), jsig_refused())
+      assert result.stats.reused_modules == expected_hits[i]
+      assert result.stats.checked_modules == len(input.modules) - expected_hits[i]
+      assert checkdump.render(result.program) == checkdump.render(cold)
+      assert result.program.diags == cold.diags
+      i = i + 1
+    }
+    # Same raw text but a different loader-rewritten AST must invalidate.
+    let rewritten = LoadedModule { ..c, m: edited.m }
+    let rewrite = incremental.analyze(warm.session, LoadResult { modules: [a, b, rewritten], diags: [] })
+    assert rewrite.stats.reused_modules == 2
+    assert rewrite.stats.checked_modules == 1
+  }))
+}
+
+test "prefix cache errors and limits never retain a disconnected suffix" {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = match load_std("std") {
+      Ok(s) -> s
+      Err(e) -> panic(std_load_error_text(e))
+    }
+    let a = source("a", "pub fn answer() -> Int = 42\n")
+    let b = source("b", "pub fn other() -> Int = 1\n")
+    let loaded = LoadResult { modules: [a, b], diags: [] }
+    let fresh = incremental.new(std, ct_default(), jsig_refused(), refused_probe, 10, 10000)
+    let warm = incremental.analyze(fresh, loaded)
+    let broken = source("broken", "pub fn (\n")
+    let loader = LocDiag { path: "loader", d: broken.pdiags[0] }
+    let failed = incremental.analyze(warm.session, LoadResult { modules: [a, b], diags: [loader] })
+    assert failed.stats.reused_modules == 0
+    assert failed.stats.retained_modules == 0
+    assert failed.program.diags[0] == loader
+    let bad = source("bad", "pub fn bad() -> Int = false\n")
+    let input = LoadResult { modules: [a, bad, b], diags: [] }
+    let recovered = incremental.analyze(warm.session, input)
+    assert recovered.stats.reused_modules == 1
+    assert recovered.stats.retained_modules == 1
+    let again = incremental.analyze(recovered.session, input)
+    assert again.stats.reused_modules == 1
+    assert again.stats.checked_modules == 2
+    assert again.program.diags == analyze_program(input, std, ct_default(), jsig_refused()).diags
+    let evicted = incremental.analyze(incremental.evict(warm.session), loaded)
+    assert evicted.stats.reused_modules == 0
+    assert evicted.stats.checked_modules == 2
+    let bounded = incremental.new(std, ct_default(), jsig_refused(), refused_probe, 1, 10000)
+    let one = incremental.analyze(bounded, loaded)
+    assert one.stats.retained_modules == 1
+    assert incremental.analyze(one.session, loaded).stats.reused_modules == 1
+    let no_text = incremental.new(std, ct_default(), jsig_refused(), refused_probe, 10, 0)
+    assert incremental.analyze(no_text, loaded).stats.retained_modules == 0
+    let opts = ct_default()
+    let ffi = incremental.new(std, CtOpts { ..opts, ffi: true }, jsig_refused(), refused_probe, 10, 10000)
+    assert incremental.analyze(ffi, loaded).stats.retained_modules == 0
+  }))
+}
+
+test "prefix cache stops at Java queries but still reuses pure code with Java enabled" {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = match load_std("std") {
+      Ok(s) -> s
+      Err(e) -> panic(std_load_error_text(e))
+    }
+    let pure = source("pure", "pub fn answer() -> Int = 42\n")
+    let producer = source("producer",
+      "use java \"java.util.ArrayList\"\npub fn items() -> ArrayList !io = ArrayList.new()\n")
+    let consumer = source("consumer",
+      "use producer\npub fn count() -> Int !io = producer.items().size()\n")
+    let loaded = LoadResult { modules: [pure, producer, consumer], diags: [] }
+    let js = jsig_real()
+    let fresh = incremental.new(std, ct_default(), js, query_probe, 10, 10000)
+    let first = incremental.analyze(fresh, loaded)
+    assert len(first.program.diags) == 0
+    assert first.stats.retained_modules == 1
+    let warm = incremental.analyze(first.session, loaded)
+    assert len(warm.program.diags) == 0
+    assert warm.stats.reused_modules == 1
+    assert warm.stats.checked_modules == 2
+    assert warm.stats.retained_modules == 1
+    assert checkdump.render(warm.program) == checkdump.render(analyze_program(loaded, std, ct_default(), js))
+  }))
+}
+
+test "prefix cache rechecks std identity and refuses negative budgets" {
+  io.with_fs_real(() => io.with_env_real(() => {
+    let std = match load_std("std") {
+      Ok(s) -> s
+      Err(e) -> panic(std_load_error_text(e))
+    }
+    let raw = source("pretend", "pub fn answer() -> Int = 42\n")
+    let input = LoadResult { modules: [LoadedModule { ..raw, path: "std/list.dawn" }], diags: [] }
+    let owner = incremental.new(std, ct_default(), jsig_refused(), refused_probe, 10, 10000)
+    let first = incremental.analyze(owner, input)
+    assert len(first.program.diags) == 0
+    assert first.stats.retained_modules == 1
+    assert first.program.modules[0].class_name == "std/list"
+    let (changed, _) = envmem.with_env_table("/different-cwd", [],
+      () => incremental.analyze(first.session, input))
+    assert changed.stats.reused_modules == 0
+    assert changed.stats.checked_modules == 1
+    assert changed.program.modules[0].class_name == "pretend"
+    for (modules, units) in [(-1, 10), (10, -1)] {
+      let result = catch_panic(() => {
+        let _ = incremental.new(std, ct_default(), jsig_refused(), refused_probe, modules, units)
+        ()
+      })
+      match result {
+        Err(_) -> ()
+        Ok(_) -> { assert false }
+      }
+    }
+  }))
+}

--- a/selfhost/src/driver/incremental.dawn
+++ b/selfhost/src/driver/incremental.dawn
@@ -1,0 +1,120 @@
+# One immutable owner fixes the analysis world and retains only a safe prefix.
+# The caller commits its returned session together with the query Program.
+# No global cache or resource lease lives here; abandoning a session releases
+# its replay state, while the caller remains responsible for closing its lease.
+
+use std/io.{Env}
+use std/str
+use driver/analyze.{
+  LoadedModule, LoadResult, Program, CheckedMod, ModuleStep,
+  initial_carry, analyze_module_step
+}
+use driver/stdlib.{StdCtx, std_module_of}
+use check/cx.{Cx}
+use check/jsig.{Jsig, JsigProbe}
+use ir/interp.{CtOpts}
+
+type Entry = { raw: LoadedModule, std_identity: Option[String], step: ModuleStep }
+type State = {
+  std: StdCtx,
+  opts: CtOpts,
+  js: Jsig,
+  probe: fn(Jsig) -> JsigProbe !io,
+  prefix: List[Entry],
+  max_modules: Int,
+  max_text_units: Int
+}
+
+## Construct a new owner when std, options, captured plan or lease changes.
+## Keeping the representation private prevents grafting an old prefix into
+## a new world; the host must drop this owner before releasing its Java lease.
+pub opaque type Session = State
+
+pub type Stats = {
+  reused_modules: Int,
+  checked_modules: Int,
+  comptime_modules: Int,
+  retained_modules: Int,
+  retained_text_units: Int
+}
+
+pub type Update = { session: Session, program: Program, stats: Stats }
+
+pub fn new(
+  std: StdCtx, opts: CtOpts, js: Jsig, probe: fn(Jsig) -> JsigProbe !io,
+  max_modules: Int, max_text_units: Int
+) -> Session = {
+  if max_modules < 0 || max_text_units < 0 { panic("negative analysis cache limit") }
+  State {
+    std: std, opts: opts, js: js, probe: probe, prefix: [],
+    max_modules: max_modules, max_text_units: max_text_units
+  }
+}
+
+## Eviction drops replay state, not the caller's current query Program.
+pub fn evict(owner: Session) -> Session = {
+  let session: State = owner
+  State { ..session, prefix: [] }
+}
+
+fn same_input(a: LoadedModule, b: LoadedModule) -> Bool = a == b
+
+pub fn analyze(owner: Session, loaded: LoadResult) -> Update !Env !io = {
+  let session: State = owner
+  let probe = session.probe(session.js)
+  var carry = initial_carry(session.std)
+  var diags = loaded.diags
+  var modules: List[CheckedMod] = []
+  var prefix: List[Entry] = []
+  var matching = len(loaded.diags) == 0 && not session.opts.ffi
+  var retaining = matching
+  var text_units = 0
+  var reused = 0
+  var checked = 0
+  var ct_runs = 0
+  var index = 0
+  for raw in loaded.modules {
+    # std identity depends on canonical paths, including the current Env.
+    # Recompute it even for a hit; raw text alone is never a cache key.
+    let identity = std_module_of(session.std, raw.path)
+    let hit = matching && index < len(session.prefix) &&
+      same_input(raw, session.prefix[index].raw) &&
+      identity == session.prefix[index].std_identity
+    let step = if hit {
+      reused = reused + 1
+      session.prefix[index].step
+    } else {
+      # Once the prefix differs, never reconnect to an old suffix.
+      matching = false
+      let queries_before = probe.queries()
+      let computed = analyze_module_step(raw, carry, session.std, session.opts, probe.jsig, None)
+      checked = checked + computed.check_runs
+      ct_runs = ct_runs + computed.comptime_runs
+      if len(computed.diags) != 0 || probe.queries() != queries_before { retaining = false }
+      # Tooling must use the original oracle, not keep or mutate this run's
+      # observation counter through a stored checker context.
+      let cx = Cx { ..computed.checked.cx, jsig: session.js }
+      ModuleStep { ..computed, checked: CheckedMod { ..computed.checked, cx: cx } }
+    }
+    carry = step.after
+    diags = diags ++ step.diags
+    modules = modules ++ [step.checked]
+    let units = str.len(raw.text)
+    if retaining && len(prefix) < session.max_modules &&
+      units <= session.max_text_units - text_units {
+        prefix = prefix ++ [Entry { raw: raw, std_identity: identity, step: step }]
+        text_units = text_units + units
+      } else {
+        retaining = false
+      }
+    index = index + 1
+  }
+  Update {
+    session: State { ..session, prefix: prefix },
+    program: Program { modules: modules, diags: diags },
+    stats: Stats {
+      reused_modules: reused, checked_modules: checked, comptime_modules: ct_runs,
+      retained_modules: len(prefix), retained_text_units: text_units
+    }
+  }
+}

--- a/selfhost/src/lsp/server.dawn
+++ b/selfhost/src/lsp/server.dawn
@@ -20,13 +20,15 @@ use json/value.{Json, JNull, JBool, JNum, JInt, JStr, JArr, JObj, error_text}
 use json/render.{render}
 use driver/analyze.{
   Program, ProjectPlan, LocDiag,
-  analyze_program, analyze_standalone, standalone_entry, project_plan,
+  analyze_standalone, standalone_entry, project_plan,
   project_module_path, load_entries_over, canon
 }
 use compiler_plan/source
+use driver/incremental
+use driver/fsmem
 use compiler_plan/envmem
 use ir/interp.{ct_default}
-use check/jsig.{JsigLease, jsig_refused_lease}
+use check/jsig.{Jsig, JsigLease, JsigProbe, jsig_refused_lease, refused_probe}
 use driver/stdlib.{StdCtx, load_std, std_load_error_text}
 use check/checker.{exports_of, visible_bins}
 use lsp/lspq.{QCx, Target, find_target}
@@ -407,7 +409,8 @@ fn hex_digit(v: Int) -> Char =
 ## so the server can publish it as an ordinary project diagnostic.
 pub type LspLeaseHost = {
   standalone: fn() -> JsigLease !io,
-  project: fn(source.SourcePlan) -> Result[JsigLease, LocDiag] !io
+  project: fn(source.SourcePlan) -> Result[JsigLease, LocDiag] !io,
+  probe: fn(Jsig) -> JsigProbe !io
 }
 
 type WorkspaceIdentity = {
@@ -452,6 +455,8 @@ type Workspace = {
   prog: Option[Program],
   entry_by_uri: Map[String, String],
   lease: JsigLease,
+  cache: incremental.Session,
+  analysis_stats: Option[incremental.Stats],
   diag_by_uri: Map[String, List[Json]]
 }
 
@@ -1342,16 +1347,21 @@ fn rebuild_workspace(st: LspState, ws0: Workspace) -> Workspace !Fs !Env !io =
       Workspace {
         ..ws0,
         prog: no_prog,
+        cache: incremental.evict(ws0.cache),
+        analysis_stats: None,
         entry_by_uri: no_entries,
         diag_by_uri: conflict_diagnostics(st, ws0.path_by_uri, paths)
       }
     }
     InputsReady(overlay, entries, entry_by_uri) -> {
       let loaded = load_entries_over(ws0.plan, entries, overlay)
-      let prog = analyze_program(loaded, st.std, ct_default(), ws0.lease.jsig)
+      let update = incremental.analyze(ws0.cache, loaded)
+      let prog = update.program
       Workspace {
         ..ws0,
         prog: Some(prog),
+        cache: update.session,
+        analysis_stats: Some(update.stats),
         entry_by_uri: entry_by_uri,
         diag_by_uri: diagnostics_of_program(st, ws0.path_by_uri, prog)
       }
@@ -1389,6 +1399,8 @@ fn activate_workspace(
         prog: no_prog,
         entry_by_uri: no_entries,
         lease: lease,
+        cache: incremental.new(st.std, ct_default(), lease.jsig, st.host.probe, 128, 1048576),
+        analysis_stats: None,
         diag_by_uri: no_diags
       }
       match catch_panic(() => rebuild_workspace(st, candidate)) {
@@ -2004,7 +2016,8 @@ test "a bundled std buffer keeps its std identity through the document seam" {
       standalone: Some(jsig_refused_lease()),
       host: LspLeaseHost {
         standalone: () => jsig_refused_lease(),
-        project: (_plan: source.SourcePlan) => Ok(jsig_refused_lease())
+        project: (_plan: source.SourcePlan) => Ok(jsig_refused_lease()),
+        probe: refused_probe
       },
       lifecycle: Running
     }
@@ -2097,10 +2110,75 @@ fn def_probe_state(std: StdCtx) -> LspState = {
     standalone: Some(jsig_refused_lease()),
     host: LspLeaseHost {
       standalone: () => jsig_refused_lease(),
-      project: (_plan: source.SourcePlan) => Ok(jsig_refused_lease())
+      project: (_plan: source.SourcePlan) => Ok(jsig_refused_lease()),
+      probe: refused_probe
     },
     lifecycle: Running
   }
+}
+
+test "workspace commits prefix cache with its Program and drops it on conflict" {
+  let root = fsmem.MEM_BASE ++ "/prefix-project"
+  let path = root ++ "/src/main.dawn"
+  let uri = "file://" ++ path
+  let text = "use lib\npub fn answer() -> Int = lib.value() + 1\n"
+  var files = fsmem.mem_std(fsmem.MEM_BASE)
+  files = fsmem.mem_put(files, root ++ "/dawn.toml", "schema = 1\nname = \"prefix_project\"\n")
+  files = fsmem.mem_put(files, root ++ "/src/lib.dawn", "pub fn value() -> Int = 41\n")
+  files = fsmem.mem_put(files, path, text)
+  let _ = fsmem.with_fs_mem(files, () => io.with_proc_real(() =>
+      envmem.with_env_table(fsmem.MEM_BASE, [], () => {
+        let std = match load_std(fsmem.mem_std_dir(fsmem.MEM_BASE)) {
+          Ok(s) -> s
+          Err(e) -> panic(std_load_error_text(e))
+        }
+        let plan = project_plan(source.SourceFile(path))
+        let identity = workspace_identity(plan)
+        let doc = Doc {
+          uri: uri, version: 1, path: Some(path), canonical_path: Some(path),
+          text: text, view: view_of(text), ls: line_starts_of(text),
+          analysis: WorkspaceMember(identity)
+        }
+        let base = def_probe_state(std)
+        let st = LspState { ..base, docs: map.insert(base.docs, uri, doc) }
+        let lease = jsig_refused_lease()
+        let empty = Workspace {
+          plan: plan, path_by_uri: map.insert(map.empty(), uri, path),
+          prog: None, entry_by_uri: map.empty(), lease: lease,
+          cache: incremental.new(std, ct_default(), lease.jsig, refused_probe, 128, 1048576),
+          analysis_stats: None, diag_by_uri: map.empty()
+        }
+        let first = rebuild_workspace(st, empty)
+        assert len(first.prog.expect("first Program").diags) == 0
+        assert first.analysis_stats.expect("first counts").checked_modules == 2
+        let warm = rebuild_workspace(st, first)
+        assert warm.analysis_stats.expect("warm counts").reused_modules == 2
+        assert warm.analysis_stats.expect("warm counts").checked_modules == 0
+        let changed = text ++ "# edit\n"
+        let edited = Doc { ..doc, text: changed, view: view_of(changed), ls: line_starts_of(changed), version: 2 }
+        let next = LspState { ..st, docs: map.insert(st.docs, uri, edited) }
+        let updated = rebuild_workspace(next, warm)
+        assert len(updated.prog.expect("updated Program").diags) == 0
+        assert updated.analysis_stats.expect("edited counts").reused_modules == 1
+        assert updated.analysis_stats.expect("edited counts").checked_modules == 1
+        assert map.get(updated.entry_by_uri, uri) == Some("main")
+        let duplicate_uri = "file://" ++ root ++ "/src/./main.dawn"
+        let duplicate = Doc { ..doc, uri: duplicate_uri }
+        let conflicted = LspState { ..next, docs: map.insert(next.docs, duplicate_uri, duplicate) }
+        let conflict = rebuild_workspace(conflicted,
+          Workspace { ..updated, path_by_uri: map.insert(updated.path_by_uri, duplicate_uri, path) })
+        match conflict.prog {
+          None -> ()
+          Some(_) -> { assert false }
+        }
+        assert conflict.analysis_stats == None
+        assert len(map.keys(conflict.entry_by_uri)) == 0
+        let restored = rebuild_workspace(next,
+          Workspace { ..conflict, path_by_uri: updated.path_by_uri })
+        assert len(restored.prog.expect("restored Program").diags) == 0
+        assert restored.analysis_stats.expect("restored counts").reused_modules == 0
+        assert restored.analysis_stats.expect("restored counts").checked_modules == 2
+      })))
 }
 
 ## A buffer that names a std function, deliberately written outside the

--- a/selfhost/src/main.dawn
+++ b/selfhost/src/main.dawn
@@ -79,7 +79,7 @@ use c/infer
 use c/emitc
 use c/cdriver
 use jvm/jfold.{fold_call}
-use jvm/jreflect.{jsig_real, jsig_for}
+use jvm/jreflect.{jsig_real, jsig_for, query_probe}
 use check/jsig.{JsigLease}
 use c/emitc.{EmitMod}
 use check/tast.{TModule}
@@ -2414,7 +2414,8 @@ fn dispatch() -> Unit !Fs !Proc !Env !Exit !Console !io = {
       } else if mode == "lsp" {
         run_lsp(lsp_std_flag(rest), LspLeaseHost {
           standalone: lsp_standalone_lease,
-          project: lsp_target_lease
+          project: lsp_target_lease,
+          probe: query_probe
         })
       } else if mode == "lock" {
         run_lock(rest)

--- a/selfhost/src/nmain.dawn
+++ b/selfhost/src/nmain.dawn
@@ -32,7 +32,7 @@ use front/token.{Diag}
 use front/diag
 use driver/stdlib.{StdCtx, StdLoadError, load_std, std_load_error_text, std_load_is_bug}
 use ir/interp.{ct_default}
-use check/jsig.{JsigLease, jsig_refused, jsig_refused_lease}
+use check/jsig.{JsigLease, jsig_refused, jsig_refused_lease, refused_probe}
 use driver/analyze.{Program, LocDiag, load_file, load_target, analyze_program}
 use check/tast.{TModule}
 use c/cdriver
@@ -1001,7 +1001,8 @@ fn dispatch() -> Unit !Fs !Proc !Env !Exit !Console !io = {
       } else if mode == "lsp" {
         run_lsp(lsp_std_flag(rest), LspLeaseHost {
           standalone: native_lsp_standalone_lease,
-          project: native_lsp_target_lease
+          project: native_lsp_target_lease,
+          probe: refused_probe
         })
       } else if mode == "version" || mode == "--version" {
         console_println("dawnc " ++ VERSION ++ " (native)")


### PR DESCRIPTION
## 范围

为 Ready LSP workspace 接入一代连续模块前缀缓存。opaque Session 固定 std/options/oracle；完整 LoadedModule 比较和每轮 std identity 判定，首差后重算全部后缀，不按公开签名接回旧结果。

- 只保留 clean、零 Java 查询的连续前缀；loader 错误、comptime FFI 冷回退。
- JVM/native 分别接 query_probe/refused_probe；保存的 Cx 使用原 oracle，不保留本轮计数器。
- Program、Session、entry map、diagnostics 同步提交；冲突清 replay，last close 移除整个 workspace。
- 每工作区128模块 / 1,048,576源码字符的逻辑预算。不是堆内存字节上界。
- standalone/Playground 仍为冷入口；没有新增语法、协议方法、watcher、磁盘缓存或部署。

## 验收

- JVM selfhost 619、native selfhost 485、集成夹具354测试通过；workspace 内存 Fs/Env owning test 同时守双后端真实命中、末段重算、冲突清空及恢复。
- 13组 warm/frozen-cold 完整 Program/Cx 对照；12个成功编译引擎负控全部命中明确断言（含总是cold、text-only、suffix拼回、错误/Java/loader/FFI、逐出、两种预算、std身份、负预算拒绝）。严格整套242.59s。
- 三个工作区接线负控通过：丢新Session、总是逐出、冲突保留cache。83.97s。
- 既有 LSP workspace 全18案例×20负控通过，未因加缓存削减协议/lease验收。
- B==C 固定点、独立calc发射、完整doc-check（132负控）、gatemap、budget、fmt、Core重录后复验通过。

## 实际工作量与基准

compiler-plan entry closure13模块，编辑末模块复用12、检查1。selfhost entry closure72模块：编辑main（位置71）只复用26，Java查询截断；编辑parser（位置3）复用3。目录分析74模块不是同一个口径。

同候选源码、GraalVM21.0.2、SerialGC、私有stderr观测、11轮丢前3轮：compiler-plan刷新中位119.19ms（强制cold）→61.18ms（warm），全部hover/definition/completion回复一致。原始轮次、artifact hash和限制已归档；先cold后warm、单进程每模式的小样本，不宣称通用倍数或SLA。早先与测试并行的hello_mod/selfhost样本没有稳定提速结论。RSS不是缓存独占内存。

## Core 与 CI

17份固定Core文本不变。编译器新增driver.incremental，server/main/nmain为本次接线；exitmem两处handler整数29401→29468，consolemem/lspq只生成ADT取号。exact/norm重录，无过滤放宽。

原增量job加入工作区接线负控（规划370s/timeout19min）；独立incremental-prefix job运行完整12负控（规划524s/timeout27min）。两者各为完整契约，不是可漏片的共享矩阵。

第2期报告尚未创建：等待准确HEAD的完整CI与剩余阶段清单复核，不能把此PR提交当成整期验收。后续继续稳定身份和函数级引擎，第5/7期报告仍按约定出。
