### PR TITLE
Prove fixed-header body identity and relocation in private fixtures

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1043,9 +1043,11 @@ jobs:
     # Planning update: the original complete suite took 81.07s locally and
     # the three workspace-owner mutants took 83.97s on 2026-09-08.
     # Double rounded 82+84s, plus 38s fixed overhead: 370s.
+    # The complete body identity/relocation prototype took 35.66s locally
+    # on 2026-09-08: add 2*36s, giving a 442s planning value.
     # Engine prefix mutants have their own independent owning job below.
-    # budget: 3x 370s planning value
-    timeout-minutes: 19
+    # budget: 3x 442s planning value
+    timeout-minutes: 23
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dawn-toolchain
@@ -1057,6 +1059,7 @@ jobs:
           python3 scripts/incremental-semantics-contract/probe.py
           python3 scripts/incremental-semantics-contract/cold.py
           python3 scripts/incremental-semantics-contract/lsp-prefix.py
+          python3 scripts/incremental-semantics-contract/body-probe.py --all --java-home "$JAVA_HOME" --output "$RUNNER_TEMP/incremental-body-probe"
           ./bin/dawn test scripts/incremental-semantics-contract
 
   incremental-prefix:

--- a/docs/incremental-semantics-design.md
+++ b/docs/incremental-semantics-design.md
@@ -51,13 +51,23 @@ query 记录真实语义读取，含 scope/候选集的失败查找、impl、ali
 inferred body 参与 signature，comptime 读取 body/value，不能只跟踪导出函数签名。
 语义结果与源码位置视图分别失效，避免空白改动后 definition/diagnostics 使用旧 span。
 
+第3期已完成固定 header 的私有小语料原型，见
+[函数体实验说明](../scripts/incremental-semantics-contract/body-probe.md)。
+在前置函数增加局部变量并插入非 BMP 注释后，复用侧仅检查改动函数，其余10个函数
+的 TFun 和逐 body 边界完整 Cx 经纯数据重放后与冷检查一致。源码位置只支持整个
+body 平移；函数 key 只覆盖唯一命名的顶层函数。八个可编译负控覆盖身份歧义、
+符号/捕获、主次 span、Cx符号、诊断和符号声明位置遗漏；完整实验本地35.66s。
+这是保留原取号方案的初步可行性证据，不是全语言迁移完成：nominal/type/effect
+引用、其他声明类别、非均匀位置映射、模块最终装配和双后端/Core仍须后续验证。
+默认参数合成仍由原 check_module 收尾，依赖读取/失效也未实现；不接生产缓存。
+
 ## 五、七期与报告
 
 | 期 | 交付 | 状态 |
 |---|---|---|
 | 1 | 冷路径对照、阶段基线、Java 观测 | 已验收；证据汇入第2期报告 |
 | 2 | workspace 前缀缓存、生命周期、基本逐出 | #107已合并；[验收报告](history/incremental-semantics-p2-report.md) |
-| 3 | 稳定身份、具名产物及重定位 | 原型调查，尚未实现 |
+| 3 | 稳定身份、具名产物及重定位 | 固定header私有原型通过，完整迁移未实现 |
 | 4 | query runtime、依赖失效和 header 接线 | 未开始 |
 | 5 | 函数 body 增量、standalone/Playground | 未开始；验收后报告 |
 | 6 | comptime/Java/索引与工具消费者收口 | 未开始 |

--- a/scripts/incremental-semantics-contract/BodyProbe.java
+++ b/scripts/incremental-semantics-contract/BodyProbe.java
@@ -1,0 +1,58 @@
+package contract;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/** Observe the real body's state footprint without a generated Cx Eq dictionary. */
+public final class BodyProbe {
+    public static void main(String[] args) throws Exception {
+        Class<?> probe = Class.forName("bodyprobe");
+        Object samples = probe.getMethod("samples").invoke(null);
+        var count = Arrays.stream(probe.getMethods()).filter(m -> m.getName().equals("sample_count"))
+                .findFirst().orElseThrow();
+        var at = Arrays.stream(probe.getMethods()).filter(m -> m.getName().equals("sample_at"))
+                .findFirst().orElseThrow();
+        long length = (Long) count.invoke(null, samples);
+        if (length != 11) throw new AssertionError("Expected eleven body trials");
+        for (long i = 0; i < length; i++) {
+            Object trial = at.invoke(null, samples, i);
+            Class<?> t = trial.getClass();
+            String name = (String) t.getField("name").get(trial);
+            Object before = t.getField("before").get(trial);
+            Object after = t.getField("after").get(trial);
+            Object shifted = t.getField("shifted").get(trial);
+            if (!SemanticSnapshot.same(t.getField("body").get(trial), t.getField("module_body").get(trial)))
+                throw new AssertionError(name + ": isolated header sequence differs from check_module");
+            if (!SemanticSnapshot.same(t.getField("relocated").get(trial), t.getField("shifted_body").get(trial)))
+                throw new AssertionError(name + ": relocated body differs from shifted cold check");
+            var changed = new ArrayList<String>();
+            for (var field : before.getClass().getFields()) {
+                if (Modifier.isStatic(field.getModifiers()) || field.getName().equals("jsig")) continue;
+                if (!SemanticSnapshot.same(field.get(before), field.get(after))) changed.add(field.getName());
+            }
+            changed.sort(String::compareTo);
+            var next = before.getClass().getField("next_id");
+            long allocations = next.getLong(after) - next.getLong(before);
+            if (next.getLong(shifted) - next.getLong(after) != 1000)
+                throw new AssertionError(name + ": allocation count depends on starting ID");
+            System.out.println(name + "\t" + allocations + "\t" + String.join(",", changed));
+        }
+        Object edits = probe.getMethod("edit_samples").invoke(null);
+        var editCount = Arrays.stream(probe.getMethods()).filter(m -> m.getName().equals("edit_count"))
+                .findFirst().orElseThrow();
+        var editAt = Arrays.stream(probe.getMethods()).filter(m -> m.getName().equals("edit_at"))
+                .findFirst().orElseThrow();
+        long editedLength = (Long) editCount.invoke(null, edits);
+        if (editedLength != 10) throw new AssertionError("Expected ten reused body products");
+        for (long i = 0; i < editedLength; i++) {
+            Object edit = editAt.invoke(null, edits, i);
+            Class<?> e = edit.getClass();
+            if (!SemanticSnapshot.same(e.getField("relocated").get(edit), e.getField("cold").get(edit)))
+                throw new AssertionError("edited source: relocated body differs from shifted cold check (" + i + ")");
+            if (!SemanticSnapshot.same(e.getField("replayed_cx").get(edit), e.getField("cold_cx").get(edit)))
+                throw new AssertionError("edited source: replayed Cx differs from cold body boundary (" + i + ")");
+        }
+        System.out.println("edited-source\t10\tstable keys, TFun and full body-boundary Cx agree with cold products");
+    }
+}

--- a/scripts/incremental-semantics-contract/README.md
+++ b/scripts/incremental-semantics-contract/README.md
@@ -43,6 +43,10 @@ parse replay 不是 loader 内部分段，不能从 load 相减；RSS 包含启�
 
 ## 前缀与工作区
 
+后续函数级演进的私有决策门见[第3期函数体原型](body-probe.md)：
+固定header下验证稳定函数key、真实前置编辑、TFun和完整body边界Cx重放；
+它不是已上线的函数缓存，也不代替下列生产前缀门禁。
+
 `prefix.py` 对照完整 warm/frozen-cold 产品，覆盖12个可编译引擎负控，包括预算、
 std身份变化及构造器的负预算拒绝。`lsp-prefix.py` 覆盖三个工作区接线负控，要求
 owning FAIL 后是断言失败，不把 JVM 链接错误算作成功。工作区计数测试在共享server里，

--- a/scripts/incremental-semantics-contract/body-identity.dawn.txt
+++ b/scripts/incremental-semantics-contract/body-identity.dawn.txt
@@ -1,0 +1,13 @@
+# Private function-key prototype. Inputs already carry the caller's resolved
+# module provenance; neither source positions nor checker allocation IDs are
+# declaration identities. Duplicate names are deliberately unmatchable.
+use compiler/front/ast.{FnDecl}
+
+pub type ModuleKey = { world: String, logical_module: String, emission_owner: String, source: String }
+pub type FunctionKey = { scope: ModuleKey, name: String }
+
+pub fn function_key(scope: ModuleKey, declarations: List[FnDecl], name: String) -> Option[FunctionKey] = {
+  var count = 0
+  for d in declarations { if d.name == name { count = count + 1 } }
+  if count == 1 { Some(FunctionKey { scope: scope, name: name }) } else { None }
+}

--- a/scripts/incremental-semantics-contract/body-probe.dawn.txt
+++ b/scripts/incremental-semantics-contract/body-probe.dawn.txt
@@ -1,0 +1,129 @@
+# This private probe runs the real header sequence and annotated body checker.
+# Captured states reveal writes; shifted allocation is a feasibility probe,
+# not proof that an arbitrary semantic product is safely relocatable.
+use std/map
+use std/str
+use compiler/front/parser
+use compiler/front/ast.{module_fns}
+use compiler/check/cx.{Cx, cx_new}
+use compiler/check/checker.{headers_for_body_probe, check_fn, check_module}
+use compiler/check/tast.{TFun}
+use relocation
+use identity
+use relocation.{Move}
+use identity.{ModuleKey}
+
+pub type Trial = { name: String, before: Cx, after: Cx, body: TFun, shifted: Cx, shifted_body: TFun, module_body: TFun, relocated: TFun }
+pub fn sample_count(xs: List[Trial]) -> Int = len(xs)
+pub fn sample_at(xs: List[Trial], index: Int) -> Trial = xs[index]
+
+fn fixture_text() -> String =
+  "pub effect Ask { fn ask() -> Int }\n" ++
+    "pub fn scalar(x: Int) -> Int = { let y = x + 1\n y }\n" ++
+    "pub fn identity[T](x: T) -> T = x\n" ++
+    "pub fn closure(x: Int) -> Int = { let f = (y: Int) => x + y\n f(2) }\n" ++
+    "pub fn defaulted(x: Int = 7) -> Int = x\n" ++
+    "pub fn looped(x: Int) -> Int = { var y = 0\n while y < x { y = y + 1 }\n y }\n" ++
+    "pub fn bounded[T: Show](x: T) -> String = to_string(x)\n" ++
+    "pub fn effectful() -> Int !Ask = ask()\n" ++
+    "pub fn polymorphic[!e](f: fn() -> Int !e) -> Int !e = f()\n" ++
+    "pub fn local(x: Int) -> Int = { fn nested(y: Int) -> Int = y + 1\n nested(x) }\n" ++
+    "pub fn jumping(x: Int) -> Int = { while true { if x > 0 { break } else { continue } }\n x }\n" ++
+    "pub fn wrong() -> Int = false\n"
+
+pub fn samples() -> List[Trial] !io = {
+  let text = fixture_text()
+  let (m, diagnostics) = parser.parse_module(text)
+  if len(diagnostics) != 0 { panic("body probe parse failed") }
+  let (headers, signatures) = headers_for_body_probe(cx_new(Some("probe"), Some("probe.dawn")), m, map.empty())
+  if len(headers.diags) != 0 { panic("body probe headers failed") }
+  let (_, whole) = check_module(cx_new(Some("probe"), Some("probe.dawn")), m, map.empty())
+  var cx = headers
+  var trials: List[Trial] = []
+  var index = 0
+  for d in module_fns(m) {
+    let before = cx
+    let (after, body) = check_fn(before, d, signatures[index])
+    let (shifted, shifted_body) = check_fn(Cx { ..before, next_id: before.next_id + 1000 }, d, signatures[index])
+    let expected = if d.name == "wrong" { 1 } else { 0 }
+    if len(after.diags) - len(before.diags) != expected {
+      panic("unexpected diagnostics in body probe: " ++ d.name)
+    }
+    if after.diags != shifted.diags { panic("shifted body diagnostics differ") }
+    for key in map.keys(before.syms) {
+      if map.get(before.syms, key) != map.get(after.syms, key) {
+        panic("body changed an earlier symbol: " ++ d.name)
+      }
+    }
+    trials = trials ++ [Trial { name: d.name, before: before, after: after, body: body,
+      shifted: shifted, shifted_body: shifted_body, module_body: whole.fns[index],
+      relocated: relocation.relocate(body, Move {
+        start: before.next_id, limit: after.next_id, delta: 1000, span: 0 }) }]
+    cx = after
+    index = index + 1
+  }
+  trials
+}
+
+pub type EditTrial = { relocated: TFun, cold: TFun, id_delta: Int, span_delta: Int, replayed_cx: Cx, cold_cx: Cx }
+pub fn edit_count(xs: List[EditTrial]) -> Int = len(xs)
+pub fn edit_at(xs: List[EditTrial], index: Int) -> EditTrial = xs[index]
+
+pub fn edit_samples() -> List[EditTrial] !io = {
+  let old = samples()
+  let (old_ast, _) = parser.parse_module(fixture_text())
+  let old_decls = module_fns(old_ast)
+  let edited = "# 🌅 moved source\n" ++ str.replace(fixture_text(),
+    "let y = x + 1", "let extra = x + 1\n let y = extra")
+  let (new_ast, pd) = parser.parse_module(edited)
+  if len(pd) != 0 { panic("edited probe parse failed") }
+  let new_decls = module_fns(new_ast)
+  let scope = ModuleKey {
+    world: "probe-session", logical_module: "probe", emission_owner: "probe", source: "probe.dawn"
+  }
+  let named = identity.function_key(scope, old_decls, "identity")
+  if named != identity.function_key(scope, [old_decls[2], old_decls[1]], "identity") {
+    panic("declaration reorder changed function identity")
+  }
+  if identity.function_key(scope, [old_decls[1], old_decls[1]], "identity") != None {
+    panic("duplicate declarations received a reusable identity")
+  }
+  if identity.function_key(scope, old_decls, "renamed") != None {
+    panic("missing renamed declaration matched old identity")
+  }
+  if named == identity.function_key(ModuleKey { ..scope, world: "other-session" }, old_decls, "identity") {
+    panic("function identity escaped its world")
+  }
+  let (headers, signatures) = headers_for_body_probe(cx_new(Some("probe"), Some("probe.dawn")), new_ast, map.empty())
+  if len(headers.diags) != 0 { panic("edited probe headers failed") }
+  let (_, cold) = check_module(cx_new(Some("probe"), Some("probe.dawn")), new_ast, map.empty())
+  # Replay checks only the changed first body. The complete cold check above
+  # is the oracle, not part of this replay algorithm.
+  let (first, _) = check_fn(headers, new_decls[0], signatures[0])
+  var replayed_cx = first
+  var cold_cx = first
+  var out: List[EditTrial] = []
+  var index = 1
+  while index < len(old) {
+    let saved = old[index]
+    let old_key = identity.function_key(scope, old_decls, saved.name)
+    let new_key = identity.function_key(scope, new_decls, saved.name)
+    if old_key == None || old_key != new_key { panic("unchanged function lost its stable key") }
+    let id_delta = replayed_cx.next_id - saved.before.next_id
+    let span_delta = new_decls[index].lo - old_decls[index].lo
+    if id_delta != 1 || span_delta <= 0 { panic("edit did not exercise both ID and source movement") }
+    let movement = Move {
+      start: saved.before.next_id, limit: saved.after.next_id, delta: id_delta, span: span_delta
+    }
+    let moved = relocation.relocate(saved.body, movement)
+    replayed_cx = relocation.replay(replayed_cx, saved.before, saved.after, movement)
+    let (checked, _) = check_fn(cold_cx, new_decls[index], signatures[index])
+    cold_cx = checked
+    out = out ++ [EditTrial { relocated: moved, cold: cold.fns[index], id_delta: id_delta, span_delta: span_delta,
+      replayed_cx: replayed_cx, cold_cx: cold_cx }]
+    index = index + 1
+  }
+  out
+}
+
+pub fn main() -> Unit = ()

--- a/scripts/incremental-semantics-contract/body-probe.md
+++ b/scripts/incremental-semantics-contract/body-probe.md
@@ -1,0 +1,48 @@
+# 第3期私有函数体原型
+
+这不是生产函数缓存，也不代表第3期完成。先验证“保留发射取号时，不重查函数体能否
+重定位已检查产物”这一决策门的小范围前提，再实现稳定声明身份与完整重定位。
+
+`body-probe.py` 复制编译器到新的输出目录，将 `check_module` 的原 header 前缀
+追加成私有入口；生产源码不改。11个显式签名样例覆盖局部绑定、泛型、闭包、默认参数、
+循环、trait 字典、声明效果、效果多态、局部函数、跳转和类型错误。
+
+执行方式（输出目录必须不存在）：
+
+```sh
+DAWN_BIN=/path/to/independent/worktree/bin/dawn \
+  python3 scripts/incremental-semantics-contract/body-probe.py \
+  --java-home /path/to/jdk21 --output review/body-probe-new
+```
+
+追加 `--all` 运行完整 positive 和八个编译负控；也可用 `--mutant <name>` 单跑。
+负控包括 skip-symbol、skip-captures、skip-spans、skip-operator-spans、ambiguous-key、
+skip-cx-symbols、skip-diagnostics、skip-symbol-location，分别遗漏符号、闭包捕获、
+源码位置、运算符位置、重复声明拒绝、Cx符号更新、诊断和符号声明位置。
+每个必须成功编译且命中自己的语义不一致断言，编译失败不算通过。
+
+当前原型同时验证：
+
+- 私有顺序检查得到的每个 TFun 与正常 `check_module` 的对应产物完整一致。
+- 每个函数不改变先前已有的符号；只有 `wrong` 样例新增一个诊断。
+- 起始 next_id 平移1000后，分配数量与诊断不变。
+- 纯 Dawn 数据遍历只重定位本函数区间内的符号，所得完整 TFun 与平移起点重新
+  冷检查的产物一致。独立 Java 结构比较器不依赖编译器生成的完整 Eq 字典。
+- 在前一个函数增加局部变量，并在文件前插入含非 BMP 字符的注释；复用侧只检查
+  改动函数，后面10个函数纯数据重放得到的 TFun 和每个 body 边界的完整 Cx 均与
+  冷检查一致，覆盖符号取号、码点位置、恢复诊断与旧符号保留。冷检查只作对照 oracle。
+- 私有 ModuleKey/FunctionKey 不含位置和数字 ID；函数重排不改变唯一名称的 key，
+  重复声明、缺失名称不提供 key，不同分析 world 的 key 不相等。
+
+2026-09-08 本地11例及真实编辑对拍通过。状态变化的并集为 `frame`、`next_id`、
+`syms`、`diags`、`current_tparams`、`current_eff_vars`、`loop_jumps`。
+这只是样例观察，不能据此删掉 Cx 的其他字段或断言它们在全语言中恒定。
+正常 check_module 在检查 body 之后还合成默认参数函数并更新函数表，不能遗漏。
+
+尚未完成：覆盖所有声明类别的 ModuleKey/DeclKey、nominal/type/effect身份迁移、
+所有 TAST 形态、全语言 Cx 增量拼接、非均匀源码位置映射和双后端/Core对照。
+当前 relocation 对未知表达式/语句直接失败；固定 header 下保持类型和效果引用原样，
+不能直接用于 header 已改变的会话。原型留在测试文本，不接生产路径；独立完整实验在
+incremental-semantics CI job 执行，本地 positive 加八负控共35.66s。
+每个 body 内只支持整体平移；默认参数合成仍由原 check_module 完成，未宣称整模块
+装配已迁移。当前复用条件由固定实验输入保证，尚未实现 query 依赖失效或真实缓存资格判定。

--- a/scripts/incremental-semantics-contract/body-probe.py
+++ b/scripts/incremental-semantics-contract/body-probe.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Survey body state in an isolated compiler, preserving production header order.
+
+The extracted header prefix is private test instrumentation, not a replacement
+checker. Failing anchors stop the experiment instead of silently probing a
+different phase order. No production source or emission contract is modified.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+
+from cold import ROOT, HERE, DAWN
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--java-home", required=True, type=Path)
+    variants = ["skip-symbol", "skip-captures", "skip-spans", "skip-operator-spans", "ambiguous-key",
+                "skip-cx-symbols", "skip-diagnostics", "skip-symbol-location"]
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--mutant", choices=variants)
+    modes.add_argument("--all", action="store_true", help="run the positive and all eight compiling negative controls")
+    args = parser.parse_args()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    if args.all:
+        started = time.monotonic()
+        for name in ["positive", *variants]:
+            command = [sys.executable, str(Path(__file__).resolve()), "--java-home", str(args.java_home.resolve()),
+                       "--output", str(output / name)]
+            if name != "positive":
+                command += ["--mutant", name]
+            subprocess.run(command, check=True, timeout=900)
+        elapsed = time.monotonic() - started
+        (output / "summary.json").write_text(json.dumps({"variants": ["positive", *variants],
+                                                         "elapsed_seconds": elapsed}, indent=2) + "\n")
+        print(f"OK: complete body identity/relocation prototype, {elapsed:.2f}s")
+        return
+    java = args.java_home.resolve() / "bin/java"
+    javac = args.java_home.resolve() / "bin/javac"
+    for directory in ("selfhost", "compiler-plan"):
+        shutil.copytree(ROOT / directory, output / directory,
+                        ignore=shutil.ignore_patterns("build", ".dawn"))
+    (output / "packages").symlink_to(ROOT / "packages", target_is_directory=True)
+    checker = output / "selfhost/src/check/checker.dawn"
+    source = checker.read_text()
+    start = "pub fn check_module(cx: Cx, m: Module, env: Map[String, ModExports]) -> (Cx, TModule) !io = {\n"
+    end = "  # 5. inferred functions first, in call-dependency order"
+    if source.count(start) != 1 or source.count(end) != 1:
+        raise RuntimeError("Header probe anchors drifted")
+    prefix = source.split(start, 1)[1].split(end, 1)[0]
+    checker.write_text(source + "\npub fn headers_for_body_probe(cx: Cx, m: Module, env: Map[String, ModExports]) -> (Cx, List[Sig]) !io = {\n"
+                       + prefix + "  (cx1, sigs)\n}\n")
+    fixture = output / "scripts/body-probe"
+    (fixture / "src").mkdir(parents=True)
+    (fixture / "dawn.toml").write_text((HERE / "dawn.toml").read_text())
+    (fixture / "src/bodyprobe.dawn").write_text((HERE / "body-probe.dawn.txt").read_text())
+    identity = (HERE / "body-identity.dawn.txt").read_text()
+    relocation = (HERE / "body-relocate.dawn.txt").read_text()
+    mutations = {
+        "skip-symbol": ("{ id + m.delta }", "{ id }"),
+        "skip-captures": ("ids(captures, m), position(lo, m), position(hi, m), ty)", "captures, position(lo, m), position(hi, m), ty)"),
+        "skip-spans": ("p + m.span", "p"),
+        "skip-operator-spans": ("moved, position(olo, m), position(ohi, m)", "moved, olo, ohi"),
+        "skip-cx-symbols": ("..cx, syms: syms", "..cx, syms: cx.syms"),
+        "skip-diagnostics": ("cx.diags ++ diagnostics", "cx.diags"),
+        "skip-symbol-location": ("dlo: position(s.dlo, m), dhi: position(s.dhi, m)", "dlo: s.dlo, dhi: s.dhi"),
+    }
+    expected_failure = "relocated body differs from shifted cold check"
+    if args.mutant in ("skip-cx-symbols", "skip-diagnostics", "skip-symbol-location"):
+        expected_failure = "replayed Cx differs from cold body boundary"
+    if args.mutant == "ambiguous-key":
+        if identity.count("count == 1") != 1:
+            raise RuntimeError("Identity mutation anchor drifted")
+        identity = identity.replace("count == 1", "count > 0")
+        expected_failure = "duplicate declarations received a reusable identity"
+    elif args.mutant:
+        old, new = mutations[args.mutant]
+        if relocation.count(old) != 1:
+            raise RuntimeError("Relocation mutation anchor drifted")
+        relocation = relocation.replace(old, new)
+    (fixture / "src/relocation.dawn").write_text(relocation)
+    (fixture / "src/identity.dawn").write_text(identity)
+    classes = output / "classes"
+    classes.mkdir()
+    subprocess.run([str(javac), "--release", "21", "-d", str(classes),
+                    str(HERE / "SemanticSnapshot.java"), str(HERE / "BodyProbe.java")], check=True)
+    with (output / "build.log").open("w") as log:
+        subprocess.run([DAWN, "build", str(fixture), "-o", str(output / "subject.jar")],
+                       cwd=ROOT, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=600)
+    result = subprocess.run([str(java), "-Xss512m", "-cp", str(classes) + ":" + str(output / "subject.jar"),
+                             "contract.BodyProbe"], cwd=ROOT, timeout=120,
+                            text=True, capture_output=True)
+    (output / "run.log").write_text(result.stdout + result.stderr)
+    if args.mutant:
+        if result.returncode == 0 or expected_failure not in result.stderr or "NoSuchMethodError" in result.stderr:
+            raise RuntimeError("Mutation did not reach its owning semantic comparison: " + result.stderr)
+        print("OK: compiling relocation mutant rejected: " + args.mutant)
+        return
+    if result.returncode != 0:
+        raise RuntimeError("Body probe failed: " + result.stderr)
+    (output / "state-writes.tsv").write_text(result.stdout)
+    version = subprocess.run([str(java), "-version"], text=True, capture_output=True, check=True)
+    (output / "metadata.json").write_text(json.dumps({
+        "java": version.stdout + version.stderr,
+        "production_checker_sha256": hashlib.sha256(source.encode()).hexdigest(),
+        "probe_sha256": hashlib.sha256((HERE / "body-probe.dawn.txt").read_bytes()).hexdigest(),
+        "relocation_sha256": hashlib.sha256(relocation.encode()).hexdigest(),
+        "identity_sha256": hashlib.sha256(identity.encode()).hexdigest(),
+        "note": "Eleven illustrative bodies and ten real-edit replays; fixed-header symbol and uniform code-point relocation, not general product relocation",
+    }, indent=2) + "\n")
+    print(result.stdout, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/incremental-semantics-contract/body-relocate.dawn.txt
+++ b/scripts/incremental-semantics-contract/body-relocate.dawn.txt
@@ -1,0 +1,156 @@
+# Private first relocation experiment: only body symbols move, headers stay
+# fixed. Unknown typed shapes fail rather than silently retain old references.
+# This is not the final nominal/type/effect/source-view relocation protocol.
+use std/map
+use std/list
+use compiler/check/cx.{Cx, Frame}
+use compiler/check/types.{Sym}
+use compiler/front/token.{Diag}
+use compiler/check/tast.{
+  TFun, TDefault, TExpr, TStmt, WitRef, WForward, WConcrete, WApply,
+  XInt, XBool, XUnit, XLocal, XEvRead, XCallDyn, XCallBuiltin, XCallFn,
+  XApply, XLambda, XCtor, XField, XBinary, XIf, XBlock, XBreak, XContinue,
+  TSLet, TSLocalFn, TSAssign, TSExpr, TSWhile
+}
+
+pub type Move = { start: Int, limit: Int, delta: Int, span: Int }
+
+fn position(p: Int, m: Move) -> Int = p + m.span
+
+fn symbol(id: Int, m: Move) -> Int =
+  if id >= m.start && id < m.limit { id + m.delta } else { id }
+
+fn ids(xs: List[Int], m: Move) -> List[Int] =
+  map(xs, x => symbol(x, m))
+
+fn opt_id(x: Option[Int], m: Move) -> Option[Int] =
+  match x {
+    Some(id) -> Some(symbol(id, m))
+    None -> None
+  }
+
+fn witness(w: WitRef, m: Move) -> WitRef =
+  match w {
+    WForward(id) -> WForward(symbol(id, m))
+    WConcrete(_, _) -> w
+    WApply(t, ty, args) -> WApply(t, ty, map(args, a => witness(a, m)))
+  }
+
+fn exprs(xs: List[TExpr], m: Move) -> List[TExpr] =
+  map(xs, x => expr(x, m))
+
+fn opt_expr(x: Option[TExpr], m: Move) -> Option[TExpr] =
+  match x {
+    Some(e) -> Some(expr(e, m))
+    None -> None
+  }
+
+fn expr(x: TExpr, m: Move) -> TExpr =
+  match x {
+    XInt(v, lo, hi) -> XInt(v, position(lo, m), position(hi, m))
+    XBool(v, lo, hi) -> XBool(v, position(lo, m), position(hi, m))
+    XUnit(lo, hi) -> XUnit(position(lo, m), position(hi, m))
+    XBreak(lo, hi) -> XBreak(position(lo, m), position(hi, m))
+    XContinue(lo, hi) -> XContinue(position(lo, m), position(hi, m))
+    XEvRead(key, lo, hi, ty) -> XEvRead(key, position(lo, m), position(hi, m), ty)
+    XLocal(id, name, lo, hi, ty) -> XLocal(symbol(id, m), name, position(lo, m), position(hi, m), ty)
+    XCallDyn(id, name, args, evidence, lo, hi, ty) ->
+      XCallDyn(symbol(id, m), name, exprs(args, m),
+        exprs(evidence, m), position(lo, m), position(hi, m), ty)
+    XCallBuiltin(name, args, ws, evidence, lo, hi, ty) ->
+      XCallBuiltin(name, exprs(args, m), map(ws, w => witness(w, m)),
+        exprs(evidence, m), position(lo, m), position(hi, m), ty)
+    XCallFn(owner, name, args, ws, evidence, tr, lo, hi, ty) ->
+      XCallFn(owner, name, exprs(args, m), map(ws, w => witness(w, m)),
+        exprs(evidence, m), tr, position(lo, m), position(hi, m), ty)
+    XApply(target, args, evidence, lo, hi, ty) ->
+      XApply(expr(target, m), exprs(args, m),
+        exprs(evidence, m), position(lo, m), position(hi, m), ty)
+    XLambda(params, names, body, captures, lo, hi, ty) ->
+      XLambda(ids(params, m), names, expr(body, m),
+        ids(captures, m), position(lo, m), position(hi, m), ty)
+    XCtor(adt, ci, written, slots, spread, lo, hi, ty) ->
+      XCtor(adt, ci, exprs(written, m), slots, opt_expr(spread, m), position(lo, m), position(hi, m), ty)
+    XField(target, index, lo, hi, ty) -> XField(expr(target, m), index, position(lo, m), position(hi, m), ty)
+    XBinary(op, a, b, wit, olo, ohi, lo, hi, ty) -> {
+      let moved = match wit {
+        Some(w) -> Some(witness(w, m))
+        None -> None
+      }
+      XBinary(op, expr(a, m), expr(b, m), moved, position(olo, m), position(ohi, m), position(lo, m), position(hi, m), ty)
+    }
+    XIf(cond, thn, els, lo, hi, ty) ->
+      XIf(expr(cond, m), expr(thn, m), opt_expr(els, m), position(lo, m), position(hi, m), ty)
+    XBlock(stmts, tail, lo, hi, ty) ->
+      XBlock(map(stmts, s => stmt(s, m)), opt_expr(tail, m), position(lo, m), position(hi, m), ty)
+    _ -> panic("unsupported expression in symbol-only relocation prototype")
+  }
+
+fn stmt(s: TStmt, m: Move) -> TStmt =
+  match s {
+    TSLet(id, name, init, lo, hi) ->
+      TSLet(opt_id(id, m), name, expr(init, m), position(lo, m), position(hi, m))
+    TSLocalFn(id, name, params, names, body, captures, lo, hi) ->
+      TSLocalFn(symbol(id, m), name, ids(params, m), names,
+        expr(body, m), ids(captures, m), position(lo, m), position(hi, m))
+    TSAssign(id, name, value, lo, hi) ->
+      TSAssign(symbol(id, m), name, expr(value, m), position(lo, m), position(hi, m))
+    TSExpr(e, lo, hi) -> TSExpr(expr(e, m), position(lo, m), position(hi, m))
+    TSWhile(cond, body, jumps, lo, hi) ->
+      TSWhile(expr(cond, m), expr(body, m), jumps, position(lo, m), position(hi, m))
+    _ -> panic("unsupported statement in symbol-only relocation prototype")
+  }
+
+pub fn relocate(f: TFun, m: Move) -> TFun = {
+  let defaults = map(f.defaults, d => match d {
+    Some(value) -> Some(TDefault { body: expr(value.body, m),
+      dict_syms: ids(value.dict_syms, m) })
+    None -> None
+  })
+  TFun { ..f, param_syms: ids(f.param_syms, m),
+    dict_syms: ids(f.dict_syms, m), ev_syms: ids(f.ev_syms, m),
+    defaults: defaults, body: expr(f.body, m) }
+}
+
+# Replay the observed fixed-header body delta, keeping the new module's header
+# and earlier symbols. Full Cx comparison in the probe detects omitted writes;
+# this is intentionally not a claim that these are all language-wide writes.
+pub fn replay(cx: Cx, before: Cx, after: Cx, m: Move) -> Cx = {
+  var syms = cx.syms
+  for id in map.keys(after.syms) {
+    if id >= m.start && id < m.limit {
+      let s = map.get(after.syms, id).expect("saved symbol")
+      let cell = match s.cell_of {
+        Some((id, ty)) -> Some((symbol(id, m), ty))
+        None -> None
+      }
+      syms = map.insert(syms, symbol(id, m), Sym { ..s,
+        dlo: position(s.dlo, m), dhi: position(s.dhi, m), cell_of: cell })
+    }
+  }
+  let frame = after.frame
+  if len(frame.lambda_stack) != 0 || len(frame.loop_stack) != 0 {
+    panic("prototype cannot replay a body with an unfinished nested frame")
+  }
+  let scopes = map(frame.scopes, scope => {
+    var moved = scope
+    for name in map.keys(scope) { moved = map.insert(moved, name, symbol(map.get(scope, name).expect("scope symbol"), m)) }
+    moved
+  })
+  var dictionaries = frame.dict_syms
+  for key in map.keys(dictionaries) {
+    dictionaries = map.insert(dictionaries, key, symbol(map.get(dictionaries, key).expect("dictionary symbol"), m))
+  }
+  var evidence = frame.eff_witness
+  for key in map.keys(evidence) {
+    let (lo, hi, name) = map.get(evidence, key).expect("effect witness")
+    evidence = map.insert(evidence, key, (position(lo, m), position(hi, m), name))
+  }
+  let diagnostics = map(list.drop(after.diags, len(before.diags)), d =>
+    Diag { ..d, lo: position(d.lo, m), hi: position(d.hi, m) })
+  Cx { ..cx, syms: syms, next_id: after.next_id + m.delta,
+    frame: Frame { ..frame, scopes: scopes, dict_syms: dictionaries, eff_witness: evidence },
+    diags: cx.diags ++ diagnostics,
+    current_tparams: after.current_tparams, current_eff_vars: after.current_eff_vars,
+    current_tparam_bounds: after.current_tparam_bounds, loop_jumps: after.loop_jumps }
+}


### PR DESCRIPTION
## Summary

- Add a private P3 decision-gate prototype, not production function caching.
- Compare eleven annotated body products with normal check_module, then relocate existing products without executing the checker on the replay side.
- A real preceding-body edit plus a non-BMP source prefix replays ten later bodies: complete TFun and every body-boundary Cx agree with cold analysis, including symbol IDs, code-point spans, previous symbols, and recovery diagnostics.
- Prototype function keys reject ambiguous names and separate analysis worlds. The complete positive plus eight compiling negative controls runs in CI; 35.66s locally, reflected in the job budget.

## Limits

Headers stay fixed semantically. This does not yet cover nominal/type/effect ID migration, all declaration or TAST forms, nonuniform source mapping, final module assembly, dependency invalidation, or backend acceptance. Default-argument synthesis remains in the original checker. No production compiler sources, emission contract, golden normalization, deployment, or release changes.

## Validation

- Complete prototype: positive, eight compiling mutants, full structural TFun/Cx comparisons pass.
- Full doc-check: 118 documents and 132 negative controls pass.
- Gate map: 138 gates, 2337 of 2387 tracked paths watched, remaining 50 already recorded.
- CI budget and diff checks pass.

P2 report was merged separately in #108. P3 remains in progress.