### PR TITLE
Index impl and trait default headers by declaration identity

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1096,11 +1096,11 @@ jobs:
     # allowance. Do not push projection past
     # the run-pole by appending this growing suite to its serial critical path.
     # The six production producer mutants took 94.65s on the same date.
-    # Named function headers took 42.50s; retain that over the later 29.63s.
+    # Named function/method headers and ten mutants took 61.17s locally.
     # Identity's eight mutants took 36.38s and move here from projection.
-    # 2*(69+95+43+37)+38=526s planning value.
-    # budget: 3x 526s planning value
-    timeout-minutes: 27
+    # 2*(69+95+62+37)+38=564s planning value.
+    # budget: 3x 564s planning value
+    timeout-minutes: 29
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/dawn-toolchain
@@ -3332,10 +3332,10 @@ jobs:
     # Run 34159136910 took 324s with identity. Keep the conservative 418s
     # base and add 2*13s for state products (12.70s local on 2026-09-08).
     # Allocation's separate target took 12.08s locally on 2026-09-08.
-    # Keep the 470s base; the named-header target took 37.12s locally.
-    # Add 2*38s = 546s without reducing the prior allowance.
-    # budget: 3x 546s planning value (see the note above)
-    timeout-minutes: 28
+    # Keep the 470s base; the named function/method target took 46.86s locally.
+    # Add 2*47s = 564s without reducing the prior allowance.
+    # budget: 3x 564s planning value (see the note above)
+    timeout-minutes: 29
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/incremental-semantics-design.md
+++ b/docs/incremental-semantics-design.md
@@ -278,6 +278,14 @@ const、impl方法、trait默认实现与test的有序产物。assemble_module_b
 不能用旧列表下标配新语法。此入口先覆盖顶层函数；impl/default/test各自的身份类别
 仍沿用identity，需后续接线，不将顶层函数索引宣称完整header缓存或依赖验证。
 
+impl方法和trait默认实现已建立独立具名视图：impl的真实注册信息按当前源码
+区间定位，方法签名读取ModuleHeaders.impl_sigs；trait默认签名读取同次Cx.traits。
+两类key分别为ImplHead/MethodDecl和TraitDecl/MethodDecl，不以同名方法互相替代。
+视图保存注册身份，不自行重算或改变现有body输出中的impl_of/default_of；这两个输出
+标签仍须沿用checker既有规则，并在后续重放对照中验证。声明级来源不代表依赖有效。
+重排header对照已按key匹配两个泛型impl方法及两个效果多态trait默认签名，再用真实
+来源表投影签名、注册subject和trait ID；并未因此宣称这四个方法body已经完整重放。
+
 ### 推断函数的entry签名与封定签名
 
 分配计划应校验旧/新header的entry签名，再建立整个body区间的ID映射；封定签名是

--- a/scripts/core-golden/selfhost.norm.sha
+++ b/scripts/core-golden/selfhost.norm.sha
@@ -8,7 +8,7 @@ ece90b9945a6f1c47c5ef11ce403ee4fe5d80a13645a305817d14efc10a46404  ./c.rc.core
 def22e847d265d5dc6d22dd741db3b46eef623ff7c5083277b842e958def05f1  ./check.checker.core
 bdc97da312e2d034d8569fa7175bd81f0000c0e2e1ac99522bdf9c28f6c79a74  ./check.cx.core
 fc4387de48cd1a4c03a712ec853f2337fd82b56b4323c0279c55de8dbecedf0c  ./check.exhaustive.core
-721a5870419f4890eae4463aeed4300d4689a92a29e0a2b8b5e841e0e2f196d3  ./check.function_product.core
+503c5f7440f5a571f906ecf37c68bf1c31c1b6b89a6fc47b7913343064e4d62d  ./check.function_product.core
 fbcfb09acb7d0bdbc66eec5c5d7b65fca80e04d1ba3ef696bc7d45800a06f2de  ./check.identity.core
 11ddfce418c2da903c8359f1939fb82d57fddcf323052767e658d93984d23ca8  ./check.jsig.core
 a4ccc7835b813f8689ebeca59bd273ef9b2a3fa35fd19934d92e01905d2c16e9  ./check.passes.core
@@ -20,7 +20,7 @@ ea1a6b43487746f6191701999478e94904b8f5237abfd0c007a5dc98d233020b  ./check.source
 32847738a975b9c9715fb1804dcac0008e3f60299d96977a516bd92ff72a4a6a  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-ba57a76c5472efe42739008091466a17050d9580c388415374af9e4d3079bd70  ./dawn$pkg$compiler_plan.exitmem.core
+a7108d09c83c5d7cfea61edcaf2c7757cf9402226d44d40fe2bd0f3e998a3d39  ./dawn$pkg$compiler_plan.exitmem.core
 5e90809d7cf26b47edd232da9ed4d54e185dbaa36a4ee4b718a8c58bf6ee1c33  ./dawn$pkg$compiler_plan.manifestv.core
 f998cbf9d2c3c3712ac981592cf658f61944f43196b81f992b3d583794561297  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core

--- a/scripts/core-golden/selfhost.sha
+++ b/scripts/core-golden/selfhost.sha
@@ -8,7 +8,7 @@ a34b0b24fe75ec4636d26b62e744804cc25e933c8600b642bf537ba8d0ef77b5  ./check.body_p
 e6a70b7e8cc231aa8ba38ec76649c229a514d31655f9df6e5685ce289450804b  ./check.checker.core
 3f895ce66912d1551204eff827474f84208eb15938ad3c8197b764150477ebcc  ./check.cx.core
 81c1a17059de118ba4862b00735e3d1f89d87a98bfc4949d903c448020b5d005  ./check.exhaustive.core
-c39a518f422b5f2bc0262b772e12b8f7a9d259df73b00c8e5cdb0c9f0e1c66b1  ./check.function_product.core
+abf0e00c5dd06a385a6d11c576db589e1044742d191f8c7a67017fd81c81d5a8  ./check.function_product.core
 2fdc2b8157e1e0d335956aa33e9959c0274f3d1c2aab419e13eec3e806fe5229  ./check.identity.core
 11ddfce418c2da903c8359f1939fb82d57fddcf323052767e658d93984d23ca8  ./check.jsig.core
 0c2b89b8a44849465d1a1276235a6dda5615e04b0e81571e8acd58008e855208  ./check.passes.core
@@ -17,10 +17,10 @@ abb838cd6cbaa35d20119b3c3bdbb6d010e415fe239bf1b934ca1e83639c287b  ./check.reloca
 4196f8cd11c1043a9a0018d256a744bb16ab83974927a4186fc7aa22a06abbed  ./check.source_projection.core
 444e16b5639a8300cdec58f75bebd0fb4266725f3143101f6fe4b44f6aa98b7a  ./check.tast.core
 c0a08d7cf11afea7c2e8fc41d575cd956461759f4a175b80c3621f82ceb18993  ./check.types.core
-3b6b34ce403ee7db477496fa1954030af0a88ee24380a65368fbce724404d98d  ./dawn$pkg$compiler_plan.consolemem.core
+50d4532216301a341834a9a63590c03af38f5e07177dfe1c4afa6832a8b6fcf6  ./dawn$pkg$compiler_plan.consolemem.core
 d3a9ef24ef94410004e3b91f6676b855252b64c9e8c1e9618fe87805512be4f2  ./dawn$pkg$compiler_plan.diagnostic.core
 cf5bb5b930f88c0bd20a0ad2b71f276653c91f02cf710b49f6ed18c3adc75649  ./dawn$pkg$compiler_plan.envmem.core
-ba57a76c5472efe42739008091466a17050d9580c388415374af9e4d3079bd70  ./dawn$pkg$compiler_plan.exitmem.core
+a7108d09c83c5d7cfea61edcaf2c7757cf9402226d44d40fe2bd0f3e998a3d39  ./dawn$pkg$compiler_plan.exitmem.core
 85cd3d487c05701bb42afc408b890372743106565c6594fdb04c1ada4f0a9149  ./dawn$pkg$compiler_plan.manifestv.core
 f998cbf9d2c3c3712ac981592cf658f61944f43196b81f992b3d583794561297  ./dawn$pkg$compiler_plan.pkgfetch.core
 1d584cffaaa1673211bf9aeec2ba6689afd761d0a9ac5d47029a353f2910f904  ./dawn$pkg$compiler_plan.procmem.core
@@ -72,7 +72,7 @@ c1da51783bb4bc867d5ba841f62574789fdb69bcefd5bd962cae61ae4d2c01a9  ./jvm.ops.core
 a453487ebbff8a1e04de17df359671b385074ea4a41beff0695a3a5d727ec2da  ./jvm.rtclasses.core
 2103a2252c3781229ed03c8ac7ad1098a1afae2f440077db2c7f10e3585ec485  ./jvm.testrun.core
 90aeb971e13af3f8dc7fcf82c96fb1194ec9c0c35dc4b5085b3ac38ab3bbbed0  ./lsp.lspc.core
-f7b6486c02cccbb0e5b01ea6aad5f093cddab3ae826178e7381d9f53ae9872fb  ./lsp.lspq.core
+e0fe31050e7b684f13689f76e5cb90fd84aee74b80ce0f4c2835d07984bd7378  ./lsp.lspq.core
 bf0bf0eaec4f70f82ed7ea7fbd5a713a82d62799769b27e588353508532dbbaf  ./lsp.server.core
 47cf40a319e454f58d2f6fe32f4b8063aeb987928dbfbd608aecc3a021586ec7  ./main.core
 4b0b36a34674ebab5a616e6765f56d6a1aab302aadb992633f60b80f18e50d62  ./nmain.core

--- a/scripts/incremental-semantics-contract/README.md
+++ b/scripts/incremental-semantics-contract/README.md
@@ -103,8 +103,10 @@ owner和原函数名查找签名，别名不替代声明身份。该案例不覆
 
 function_product从真实ModuleHeaders构建顶层函数的具名header索引，保持当前语法与entry
 签名配对；重排案例按DeclKey读取旧body，再按当前keys顺序装配。function-products.py
-五个编译负控守来源、owner、签名错位、多余签名及重复声明身份；不是跨revision header
-有效性证明，impl/default/test的具名header接线仍未完成。
+十个编译负控守来源、owner、签名错位、多余签名、重复声明、impl参数/角色与trait默认
+元数据。独立Methods视图保留impl/default分组顺序，读取真实注册ImplI和trait MethodSig，
+不把同名方法混为一个key。header重排案例已投影两个泛型impl方法及两个效果多态默认
+方法的签名/subject/trait ID；尚未用这些视图重放方法body，也不是header依赖有效性证明。
 
 `projection.py` 补源码边界分裂、token/断言来源、旧断言文本及checker两条evidence
 构造分支的六个成功编译负控，另有callee owner、模块别名表和签名冲突拒绝的三个

--- a/scripts/incremental-semantics-contract/function-products.py
+++ b/scripts/incremental-semantics-contract/function-products.py
@@ -16,6 +16,7 @@ from projection import owning
 def main():
     started = time.monotonic()
     title = "function products bind entry signatures to stable current declarations"
+    method_title = "method products preserve impl and default owners across declaration reorder"
     path = Path("selfhost/src/check/function_product.dawn")
     original = (ROOT / path).read_text()
     mutations = [
@@ -25,23 +26,33 @@ def main():
         ("signature-tail", "if function != len(checked.sigs) { return None }", ""),
         ("ambiguous-identity", "if map.get(locations, key) != Some((declaration, None)) { return None }", "if false { return None }"),
     ]
+    method_mutations = [
+        ("impl-owner", "info.owner == checked.cx.owner_class", "true"),
+        ("impl-parameters", "sig.tparams != info.tparams ||", "false ||"),
+        ("impl-role", "sig.is_builtin || sig.trait_id != None || sig.op_of != None", "false"),
+        ("trait-default", "not method.has_default", "false"),
+        ("trait-owner", "info.name != name || info.owner != checked.cx.owner_class || info.src_path != checked.cx.src_path",
+         "info.name != name || info.src_path != checked.cx.src_path"),
+    ]
     with tempfile.TemporaryDirectory(prefix="dawn-function-products-") as temp:
         private = Path(temp)
         for directory in ("selfhost", "compiler-plan"):
             shutil.copytree(ROOT / directory, private / directory,
                             ignore=shutil.ignore_patterns("build", ".dawn"))
         (private / "packages").symlink_to(ROOT / "packages", target_is_directory=True)
-        subjects = [("positive", original)] + [(name, edit(original, old, new)) for name, old, new in mutations]
-        for name, source in subjects:
+        subjects = [("positive", original, title)]
+        subjects += [(name, edit(original, old, new), title) for name, old, new in mutations]
+        subjects += [(name, edit(original, old, new), method_title) for name, old, new in method_mutations]
+        for name, source, owner in subjects:
             (private / path).write_text(source)
             status, output = run("test", private / path)
             if name == "positive":
                 if status:
                     raise RuntimeError("Positive function products failed\n" + output)
-            elif not status or not owning(output, "check/function_product", title):
+            elif not status or not owning(output, "check/function_product", owner):
                 raise RuntimeError(name + " did not reach its owning assertion\n" + output)
             print("OK: function products " + name, flush=True)
-    print(f"OK: named function headers and five compiling mutants, {time.monotonic() - started:.2f}s")
+    print(f"OK: named function/method headers and ten compiling mutants, {time.monotonic() - started:.2f}s")
 
 
 if __name__ == "__main__":

--- a/scripts/incremental-semantics-contract/typed-projection.dawn.txt
+++ b/scripts/incremental-semantics-contract/typed-projection.dawn.txt
@@ -413,8 +413,8 @@ pub fn header_sample() -> HeaderTrial !io = {
   let second_type = "type Second[T, !e] = { value: T }\n"
   let first_alias = "opaque type Wrapped[T, !e] = fn(T) -> T !e\n"
   let second_alias = "alias Callback[T, !e] = fn(T) -> T !e\n"
-  let first_trait = "trait Forward[T] { fn forward(x: T, f: fn() -> Int !e) -> Int !e }\n"
-  let second_trait = "trait Repeat[T] { fn repeat(x: T, f: fn() -> Int !e) -> Int !e }\n"
+  let first_trait = "trait Forward[T] {\n fn forward(x: T, f: fn() -> Int !e) -> Int !e\n fn forward_twice(x: T, f: fn() -> Int !e) -> Int !e = forward(x, f) + forward(x, f)\n}\n"
+  let second_trait = "trait Repeat[T] {\n fn repeat(x: T, f: fn() -> Int !e) -> Int !e\n fn repeat_twice(x: T, f: fn() -> Int !e) -> Int !e = repeat(x, f) + repeat(x, f)\n}\n"
   let first_impl = "impl[T] Forward[List[T]] { fn forward(x: List[T], f: fn() -> Int !e) -> Int !e = f() }\n"
   let second_impl = "impl[T] Repeat[List[T]] { fn repeat(x: List[T], f: fn() -> Int !e) -> Int !e = f() }\n"
   let tail = "pub fn thru[!e](g: fn() -> Int !e) -> Int !e = g()\n" ++
@@ -424,8 +424,14 @@ pub fn header_sample() -> HeaderTrial !io = {
   let (old_ast, opd) = parser.parse_module(old_text)
   let (new_ast, npd) = parser.parse_module(new_text)
   if len(opd) != 0 || len(npd) != 0 { panic("header fixture parse failed") }
-  let (before, sigs, impl_sigs) = headers_with_impls_for_body_probe(cx_new(Some("header"), Some("header.dawn")), old_ast, map.empty())
-  let (next, nsigs, new_impl_sigs) = headers_with_impls_for_body_probe(cx_new(Some("header"), Some("header.dawn")), new_ast, map.empty())
+  let old_headers = check_module_headers(cx_new(Some("header"), Some("header.dawn")), old_ast, map.empty())
+  let new_headers = check_module_headers(cx_new(Some("header"), Some("header.dawn")), new_ast, map.empty())
+  let before = old_headers.cx
+  let next = new_headers.cx
+  let sigs = old_headers.sigs
+  let nsigs = new_headers.sigs
+  let impl_sigs = old_headers.impl_sigs
+  let new_impl_sigs = new_headers.impl_sigs
   if len(before.diags) != 0 || len(next.diags) != 0 || before.next_id != next.next_id { panic("header fixture invalid") }
   let decl = module_fns(old_ast)[1]
   let ndecl = module_fns(new_ast)[1]
@@ -469,6 +475,27 @@ pub fn header_sample() -> HeaderTrial !io = {
   let plan = allocation.body_plan(old_table, new_table, body_owner,
     before.next_id, after.next_id - before.next_id, next.next_id, saved.sig, nsigs[1], saved.ev_syms).expect("body allocation plan")
   let ids = plan.ids
+  let old_methods = function_product.methods(scope, old_headers).expect("old named methods")
+  let new_methods = function_product.methods(scope, new_headers).expect("new named methods")
+  if len(function_product.impl_keys(old_methods)) != 2 || len(function_product.default_keys(old_methods)) != 2 {
+    panic("method header roles missing")
+  }
+  for key in function_product.impl_keys(new_methods) ++ function_product.default_keys(new_methods) {
+    let old_method = function_product.method(old_methods, key).expect("old method by key")
+    let new_method = function_product.method(new_methods, key).expect("new method by key")
+    match (old_method, new_method) {
+      (function_product.ImplMethod(_, _, old_sig, old_info), function_product.ImplMethod(_, _, new_sig, new_info)) -> {
+        if relocate.signature(ids, old_sig) != Some(new_sig) || relocate.ty(ids, old_info.subject) != Some(new_info.subject) ||
+            relocate.trait_id(ids, old_info.trait_id) != Some(new_info.trait_id) { panic("named impl header projection") }
+      }
+      (function_product.TraitDefault(_, _, old_sig, old_tid), function_product.TraitDefault(_, _, new_sig, new_tid)) -> {
+        if relocate.signature(ids, old_sig) != Some(new_sig) || relocate.trait_id(ids, old_tid) != Some(new_tid) {
+          panic("named default header projection")
+        }
+      }
+      _ -> panic("named method role mismatch")
+    }
+  }
   if plan.next_id != checked.next_id { panic("body allocation endpoint differs from cold") }
   if relocate.nominal(ids, old_ask) != Some(new_ask) || relocate.nominal(ids, old_tell) != Some(new_tell) {
     panic("header role mismatch")

--- a/selfhost/src/check/function_product.dawn
+++ b/selfhost/src/check/function_product.dawn
@@ -5,10 +5,10 @@
 use std/map
 use check/checker.{ModuleHeaders, check_module_headers}
 use check/cx.{Cx, ModExports, cx_new}
-use check/types.{Sig}
+use check/types.{Sig, ImplI, TraitI, MethodSig}
 use check/identity
-use check/identity.{ModuleKey, DeclKey, Named, FunctionDecl, module_key}
-use front/ast.{FnDecl, DFn}
+use check/identity.{ModuleKey, DeclKey, Named, FunctionDecl, ImplHead, MethodDecl, TraitDecl, module_key}
+use front/ast.{FnDecl, TraitMethod, DFn, DImpl, DTrait}
 use front/parser
 
 pub type Header = { key: DeclKey, syntax: FnDecl, signature: Sig }
@@ -17,12 +17,17 @@ pub opaque type Headers = Data
 
 ## An ambiguous or erroneous header set has no reusable function view. The
 ## ordinary checker still owns error recovery; refusal here changes no output.
-pub fn headers(scope: ModuleKey, checked: ModuleHeaders) -> Option[Headers] = {
-  if len(checked.cx.diags) != 0 || checked.cx.owner_class != Some(scope.emission_owner) { return None }
+fn admitted(scope: ModuleKey, checked: ModuleHeaders) -> Bool = {
+  if len(checked.cx.diags) != 0 || checked.cx.owner_class != Some(scope.emission_owner) { return false }
   match checked.cx.src_path {
-    Some(path) -> if path == "" || scope.source != path { return None }
-    None -> if scope.source != "" { return None }
+    Some(path) -> if path == "" || scope.source != path { return false }
+    None -> if scope.source != "" { return false }
   }
+  true
+}
+
+pub fn headers(scope: ModuleKey, checked: ModuleHeaders) -> Option[Headers] = {
+  if not admitted(scope, checked) { return None }
   let declarations = identity.declarations(scope, checked.syntax)
   var locations: Map[DeclKey, (Int, Option[Int])] = map.empty()
   for e in declarations { locations = map.insert(locations, e.key, (e.declaration, e.member)) }
@@ -58,6 +63,107 @@ pub fn get(headers: Headers, key: DeclKey) -> Option[Header] = { let data: Data 
   map.get(data.entries, key)
 }
 
+## Registered impl identity is not a substitute for the checker's body-output
+## tagging rules. Keep it as header provenance, not an eagerly retagged TFun.
+pub type MethodHeader =
+  | ImplMethod(key: DeclKey, syntax: FnDecl, signature: Sig, registered: ImplI)
+  | TraitDefault(key: DeclKey, syntax: TraitMethod, signature: Sig, trait_id: Int)
+
+type MethodData = { impls: List[DeclKey], defaults: List[DeclKey], entries: Map[DeclKey, MethodHeader] }
+pub opaque type Methods = MethodData
+
+pub fn methods(scope: ModuleKey, checked: ModuleHeaders) -> Option[Methods] = {
+  if not admitted(scope, checked) { return None }
+  var locations: Map[DeclKey, (Int, Option[Int])] = map.empty()
+  for e in identity.declarations(scope, checked.syntax) {
+    locations = map.insert(locations, e.key, (e.declaration, e.member))
+  }
+  var registered: Map[(Int, Int), ImplI] = map.empty()
+  for info in checked.cx.local_impls {
+    if not info.derived && info.owner == checked.cx.owner_class && info.src_path == checked.cx.src_path {
+      let span = (info.lo, info.hi)
+      if map.has(registered, span) { return None }
+      registered = map.insert(registered, span, info)
+    }
+  }
+  var entries: Map[DeclKey, MethodHeader] = map.empty()
+  var impls: List[DeclKey] = []
+  var defaults: List[DeclKey] = []
+  var declaration = 0
+  var impl_index = 0
+  for d in checked.syntax.decls {
+    match d {
+      DImpl(params, trait_name, _, _, subject, members, _, _, lo, hi) -> {
+        if impl_index >= len(checked.impl_sigs) { return None }
+        let sigs = checked.impl_sigs[impl_index]
+        let info = map.get(registered, (lo, hi))?
+        if map.get(checked.cx.traits_by_name, trait_name) != Some(info.trait_id) ||
+          len(sigs) != len(members) || len(info.tparams) != len(params) { return None }
+        let parent = ImplHead(trait_name, identity.type_shape(subject, map(params, p => p.name)))
+        let parent_key = DeclKey { scope: scope, path: [parent] }
+        if map.get(locations, parent_key) != Some((declaration, None)) { return None }
+        var member = 0
+        for syntax in members {
+          let sig = sigs[member]?
+          if sig.name != syntax.name || sig.owner != checked.cx.owner_class || sig.tparams != info.tparams ||
+            sig.is_builtin || sig.trait_id != None || sig.op_of != None { return None }
+          let key = DeclKey { scope: scope, path: [parent, Named(MethodDecl, syntax.name)] }
+          if map.get(locations, key) != Some((declaration, Some(member))) { return None }
+          entries = map.insert(entries, key, ImplMethod(key, syntax, sig, info))
+          impls = impls ++ [key]
+          member = member + 1
+        }
+        impl_index = impl_index + 1
+      }
+      DTrait(name, _, _, _, members, _, _, _, _, _, _, _) -> {
+        let tid = map.get(checked.cx.traits_by_name, name)?
+        let info = map.get(checked.cx.traits, tid)?
+        if info.name != name || info.owner != checked.cx.owner_class || info.src_path != checked.cx.src_path { return None }
+        let parent = Named(TraitDecl, name)
+        if map.get(locations, DeclKey { scope: scope, path: [parent] }) != Some((declaration, None)) { return None }
+        var signatures: Map[String, MethodSig] = map.empty()
+        for (method_name, method) in info.methods {
+          if map.has(signatures, method_name) { return None }
+          signatures = map.insert(signatures, method_name, method)
+        }
+        var member = 0
+        for syntax in members {
+          # Presence needs no equality dictionary for the entire expression AST.
+          let has_body = match syntax.body { Some(_) -> true, None -> false }
+          if has_body {
+            let method = map.get(signatures, syntax.name)?
+            if not method.has_default { return None }
+            let sig = method.sig
+            if sig.name != syntax.name || sig.owner != checked.cx.owner_class ||
+              sig.trait_id != Some(tid) || sig.is_builtin || sig.op_of != None { return None }
+            let key = DeclKey { scope: scope, path: [parent, Named(MethodDecl, syntax.name)] }
+            if map.get(locations, key) != Some((declaration, Some(member))) { return None }
+            entries = map.insert(entries, key, TraitDefault(key, syntax, sig, tid))
+            defaults = defaults ++ [key]
+          }
+          member = member + 1
+        }
+      }
+      _ -> ()
+    }
+    declaration = declaration + 1
+  }
+  if impl_index != len(checked.impl_sigs) { return None }
+  Some(MethodData { impls: impls, defaults: defaults, entries: entries })
+}
+
+pub fn impl_keys(methods: Methods) -> List[DeclKey] = { let data: MethodData = methods
+  data.impls
+}
+
+pub fn default_keys(methods: Methods) -> List[DeclKey] = { let data: MethodData = methods
+  data.defaults
+}
+
+pub fn method(methods: Methods, key: DeclKey) -> Option[MethodHeader] = { let data: MethodData = methods
+  map.get(data.entries, key)
+}
+
 test "function products bind entry signatures to stable current declarations" {
   let scope = module_key("world", "module", "module", "module.dawn")
   let (syntax, ds) = parser.parse_module("fn first(x: Int) -> Int = x\nconst K: Int = 1\nfn second() = K\n")
@@ -88,4 +194,62 @@ test "function products bind entry signatures to stable current declarations" {
   assert headers(scope, bad) == None
   # Identity must still refuse a duplicate if a caller accidentally drops diagnostics.
   assert headers(scope, ModuleHeaders { ..bad, cx: Cx { ..bad.cx, diags: [] } }) == None
+}
+
+test "method products preserve impl and default owners across declaration reorder" {
+  let forward = "trait Forward[T] {\n fn forward(x: T) -> Int\n fn twice(x: T) -> Int = forward(x) + forward(x)\n}\n"
+  let repeat = "trait Repeat[T] {\n fn repeat(x: T) -> Int\n fn again(x: T) -> Int = repeat(x)\n}\n"
+  let first = "impl[T] Forward[List[T]] { fn forward(x: List[T]) -> Int = 1 }\n"
+  let second = "impl[T] Repeat[List[T]] { fn repeat(x: List[T]) -> Int = 2 }\n"
+  let (syntax, ds) = parser.parse_module(forward ++ repeat ++ first ++ second)
+  let (edited, eds) = parser.parse_module(repeat ++ forward ++ second ++ first)
+  assert ds == [] && eds == []
+  let scope = module_key("methods", "module", "module", "module.dawn")
+  let initial = cx_new(Some("module"), Some("module.dawn"))
+  let env: Map[String, ModExports] = map.empty()
+  let old = check_module_headers(initial, syntax, env)
+  let next = check_module_headers(initial, edited, env)
+  assert old.cx.diags == [] && next.cx.diags == []
+  let a = methods(scope, old).expect("old methods")
+  let b = methods(scope, next).expect("next methods")
+  let ai = impl_keys(a)
+  let bi = impl_keys(b)
+  let ad = default_keys(a)
+  let bd = default_keys(b)
+  assert len(ai) == 2 && len(ad) == 2
+  assert ai[0] == bi[1] && ai[1] == bi[0]
+  assert ad[0] == bd[1] && ad[1] == bd[0]
+  match method(b, ai[0]).expect("moved impl") {
+    ImplMethod(key, syntax, sig, info) -> {
+      assert key == ai[0]
+      assert syntax.name == "forward" && sig.name == "forward"
+      assert sig.tparams == info.tparams
+      assert len(info.tparams) == 1
+      assert Some(info.trait_id) == map.get(next.cx.traits_by_name, "Forward")
+    }
+    _ -> { assert false }
+  }
+  match method(b, ad[0]).expect("moved default") {
+    TraitDefault(key, syntax, sig, tid) -> {
+      assert key == ad[0]
+      assert syntax.name == "twice" && syntax.body != None
+      assert sig.trait_id == Some(tid)
+      assert Some(tid) == map.get(next.cx.traits_by_name, "Forward")
+      assert Some(tid) != map.get(old.cx.traits_by_name, "Forward")
+    }
+    _ -> { assert false }
+  }
+  assert methods(scope, ModuleHeaders { ..old, impl_sigs: [] }) == None
+  let sig = old.impl_sigs[0][0].expect("registered signature")
+  assert methods(scope, ModuleHeaders { ..old, impl_sigs: [[Some(Sig { ..sig, is_builtin: true })], old.impl_sigs[1]] }) == None
+  assert methods(scope, ModuleHeaders { ..old, impl_sigs: [[Some(Sig { ..sig, tparams: [] })], old.impl_sigs[1]] }) == None
+  let foreign = map(old.cx.local_impls, i => ImplI { ..i, owner: Some("foreign") })
+  assert methods(scope, ModuleHeaders { ..old, cx: Cx { ..old.cx, local_impls: foreign } }) == None
+  let tid = map.get(old.cx.traits_by_name, "Forward").expect("Forward trait")
+  let info = map.get(old.cx.traits, tid).expect("Forward info")
+  let (name, ms) = info.methods[1]
+  let missing = TraitI { ..info, methods: [info.methods[0], (name, MethodSig { ..ms, has_default: false })] }
+  assert methods(scope, ModuleHeaders { ..old, cx: Cx { ..old.cx, traits: map.insert(old.cx.traits, tid, missing) } }) == None
+  let wrong_owner = TraitI { ..info, owner: Some("foreign") }
+  assert methods(scope, ModuleHeaders { ..old, cx: Cx { ..old.cx, traits: map.insert(old.cx.traits, tid, wrong_owner) } }) == None
 }


### PR DESCRIPTION
## 内容

依赖 #118 已验收合并；本 PR 的base已切回main，仅展示本批差异。

P3 继续：function_product 新增 impl 方法/trait 默认实现的具名视图，分别保留检查
顺序，按稳定 DeclKey 查找。impl 签名来自同次 ModuleHeaders.impl_sigs，以当前源码
区间关联真实 ImplI；默认签名来自同次 Cx.traits 的 MethodSig。

保留注册来源，不用它改写 body 的 impl_of/default_of 标签。对应方法 body 的完整
重放与生产缓存调度仍待完成；不把这个 header 索引称为依赖有效性或 P3 完成。

## 验证

- 656 selfhost；B == C；独立 calc 117 类。
- 当前 function_product target 的 native 214 测试通过，46.86s；使用保留的既有
  driver 编译该 target，不声称重新构建当前 driver。
- 十个编译负控全部命中具名 owning 断言，最终61.17s。新控覆盖 impl owner、参数、
  角色以及 trait owner/default 元数据。
- 完整 typed 正例+18编译负控132.97s。header 重排对照新增两个泛型 impl 方法和
  两个效果多态 trait 默认签名的按 key 匹配，并投影签名、注册subject、trait ID。
  这不是方法 body 已重放的证明。
- 将 Option[Expr] 的有无判定改为模式匹配，避免生成整棵 AST 的相等比较；该模块
  Core 从5627行降到3282行，仅报告生成代码变化，不当作耗时基准。
- 旧96份Core逐SHA匹配8fd31f49；现有顶层header构造主体在明确局部编号映射后逐字
  不变，keys/get及原有生成函数的raw内容未变。其他旧模块只有consolemem/lspq生成名
  变化（归一后相同），以及exitmem两int30913→31003。正式normalizer未改。
  record后17dump/96hash复验通过，17固定文本未变。
- 预算守卫12负控通过。projection保留590s/30min；allocation更新564s/29min，
  native更新564s/29min；660s run-pole不变。
- 文档118/132负控/0unknown；覆盖门禁140门、2354/2404 tracked路径，50项登记未覆盖。

独立worktree，已记录handoff；无主树编辑、发布或部署。
